### PR TITLE
Feat/improve onboarding

### DIFF
--- a/src/cozy/react/components/ConfigureExtensionStep.jsx
+++ b/src/cozy/react/components/ConfigureExtensionStep.jsx
@@ -1,22 +1,13 @@
 import React from 'react'
 import {
-  useExtensionStatus,
-  extensionStatuses
+  useExtensionStatus
 } from '../helpers/extensionStatus'
 
 import InstallationStep from './InstallationStep'
-import InstalledStep from './InstalledStep'
-import ConnectedStep from './ConnectedStep'
 
 const ConfigureExtensionStep = ({ onConnected, onSkipExtension }) => {
   const extensionStatus = useExtensionStatus()
-  if (extensionStatus == extensionStatuses.installed) {
-    return <InstalledStep onConnected={onConnected} />
-  } else if (extensionStatus === extensionStatuses.connected) {
-    return <ConnectedStep />
-  } else {
-    return <InstallationStep onSkipExtension={onSkipExtension} />
-  }
+  return <InstallationStep onSkipExtension={onSkipExtension} />
 }
 
 export default ConfigureExtensionStep

--- a/src/cozy/react/components/InstallationStep/index.jsx
+++ b/src/cozy/react/components/InstallationStep/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import snarkdown from 'snarkdown'
 
 import { detect as detectBrowser } from 'detect-browser'
@@ -32,6 +32,8 @@ const browser = detectBrowser()
 const InstallationStep = ({ onExtensionInstalled, onSkipExtension }) => {
   const client = useClient()
   const { t } = useI18n()
+  const [storeVisited, setStoreVisited] = useState(false)
+
   const cozyURL = new URL(client.getStackClient().uri)
 
   const supportedPlatforms = getSupportedPlatforms()
@@ -45,6 +47,10 @@ const InstallationStep = ({ onExtensionInstalled, onSkipExtension }) => {
       onExtensionInstalled && onExtensionInstalled()
     }
   }, [extensionStatus, onExtensionInstalled])
+
+  const onGoToStore = () => {
+    setStoreVisited(true)
+  }
 
   return (
     <VerticallyCentered>
@@ -131,9 +137,10 @@ const InstallationStep = ({ onExtensionInstalled, onSkipExtension }) => {
                 label={t('InstallationStep.cta')}
                 extension="full"
                 className="u-mt-2-half"
+                onClick={onGoToStore}
               />
               <Button
-                label={t('InstallationStep.skip')}
+                label={storeVisited ? t('InstallationStep.login') : t('InstallationStep.skip')}
                 extension="full"
                 onClick={onSkipExtension}
                 theme="secondary"

--- a/src/cozy/react/locales/en.json
+++ b/src/cozy/react/locales/en.json
@@ -84,7 +84,8 @@
     "step3": "Log in with your address **%{address}** and your password!",
     "step3-oidc": "Log in with your address **%{address}** and your Cozy Pass password!",
     "cta": "Install Cozy extension",
-    "skip": "Skip"
+    "skip": "Skip",
+    "login": "Open Cozy Pass"
   },
 
   "InstallationStepMobile": {

--- a/src/cozy/react/locales/fr.json
+++ b/src/cozy/react/locales/fr.json
@@ -83,7 +83,8 @@
     "step3": "Connectez-vous avec votre adresse **%{address}** et votre mot de passe !",
     "step3-oidc": "Connectez-vous avec votre adresse **%{address}** et votre mot de passe Cozy Pass !",
     "cta": "Installer l'extension Cozy",
-    "skip": "Passer"
+    "skip": "Passer",
+    "login": "Ouvrir Cozy Pass"
   },
 
   "InstallationStepMobile": {

--- a/src/cozy/wrappers/installation-page/installation-page.component.ts
+++ b/src/cozy/wrappers/installation-page/installation-page.component.ts
@@ -77,21 +77,36 @@ export class InstallationPageComponent extends AngularWrapperComponent {
     /* Props Bindings */
     /******************/
 
+    protected async fetchHintExists(client: CozyClient) {
+        try {
+            await client
+                .getStackClient()
+                .collection('io.cozy.settings')
+                .get('hint');
+
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
     protected onSkipExtension() {
         this.vaultInstallationService.setIsInstalled();
         this.messagingService.send('installed');
     }
 
-    protected getProps(): InstallationPageProps {
-        const data = {
-            extension_installed: false, // to be replaced with client fetch
-        };
-
+    protected async getProps(): Promise<InstallationPageProps> {
         const client = this.clientService.GetClient();
+
+        const hasHint = await this.fetchHintExists(client);
+
+        const bitwardenData = {
+            extension_installed: hasHint,
+        };
 
         return {
             client: client,
-            bitwardenData: data,
+            bitwardenData: bitwardenData,
             onSkipExtension: this.onSkipExtension.bind(this),
             vaultData: this.getVaultData(),
         };
@@ -101,9 +116,9 @@ export class InstallationPageComponent extends AngularWrapperComponent {
     /* Render */
     /**********/
 
-    protected renderReact() {
+    protected async renderReact() {
         ReactDOM.render(
-            React.createElement(InstallationPage, this.getProps()),
+            React.createElement(InstallationPage, await this.getProps()),
             this.getRootDomNode()
         );
     }


### PR DESCRIPTION
Improve Installation process : 
- Replace `skip` button by `open cozy pass` when user opens extension store 
- Remove InstalledStep and ConnectedStep from InstallationPage
  - Those steps are not used anymore as user is redirected to login
page when vault is configured
- Skip first steps when Hint is already set and go directly through last step