### PR TITLE
fix: revert to old application name

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,5 +1,5 @@
 {
-  "name": "Passwords",
+  "name": "Pass",
   "name_prefix": "Cozy",
   "slug": "passwords",
   "icon": "icon.svg",


### PR DESCRIPTION
App manifest was not set correctly