### PR TITLE
fix: display correct OS icon for ciphers created from mobile apps

### DIFF
--- a/src/app/vault/icon.component.html
+++ b/src/app/vault/icon.component.html
@@ -1,6 +1,7 @@
 <div class="icon-wrapper" aria-hidden="true">
 
     <img class="icon-type" [src]="image" appFallbackSrc="{{fallbackImage}}" *ngIf="imageEnabled && image" alt="" />
+    <i class="fa fa-fw fa-lg {{icon}}" *ngIf="cipher.type === 1 && imageEnabled && !image"></i>
 
     <svg *ngIf="cipher.type === 3" class="icon-type" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32">
         <defs>

--- a/src/scss/cozy.scss
+++ b/src/scss/cozy.scss
@@ -41,3 +41,7 @@ app-button-extension {
         color: var(--primaryColor);
     }
 }
+
+app-vault-icon {
+    color: var(--secondaryTextColor);
+}


### PR DESCRIPTION
Those icons were accidentally removed in the past and are still present in mobile and browser extension versions.