### PR TITLE
fix: reword `Open Cozy Pass` to `Open my passwords`

### DIFF
--- a/src/cozy/react/locales/en.json
+++ b/src/cozy/react/locales/en.json
@@ -85,7 +85,7 @@
     "step3-oidc": "Log in with your address **%{address}** and your Cozy Pass password!",
     "cta": "Install Cozy extension",
     "skip": "Skip",
-    "login": "Open Cozy Pass"
+    "login": "Open my passwords"
   },
 
   "InstallationStepMobile": {

--- a/src/cozy/react/locales/fr.json
+++ b/src/cozy/react/locales/fr.json
@@ -84,7 +84,7 @@
     "step3-oidc": "Connectez-vous avec votre adresse **%{address}** et votre mot de passe Cozy Pass !",
     "cta": "Installer l'extension Cozy",
     "skip": "Passer",
-    "login": "Ouvrir Cozy Pass"
+    "login": "Accéder à mes mots de passe"
   },
 
   "InstallationStepMobile": {


### PR DESCRIPTION
Old text was confusing as Install page is already part of Cozy Pass so `Open Cozy Pass` was a non-sens