### PR TITLE
Feat/flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7387,6 +7387,16 @@
         "server-destroy": "^1.0.1",
         "sift": "^6.0.0",
         "url-search-params-polyfill": "^7.0.0"
+      },
+      "dependencies": {
+        "cozy-flags": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/cozy-flags/-/cozy-flags-2.7.1.tgz",
+          "integrity": "sha512-TtVhuyMSRADRr4q5LSaRjq6u03S5m1zkZRc8n3q8bfad86FizqGC02m3e/Zh4kWTwnsO0pVW+mzeVSsBqDVT/g==",
+          "requires": {
+            "microee": "^0.0.6"
+          }
+        }
       }
     },
     "cozy-device-helper": {
@@ -7410,9 +7420,9 @@
       }
     },
     "cozy-flags": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/cozy-flags/-/cozy-flags-2.7.1.tgz",
-      "integrity": "sha512-TtVhuyMSRADRr4q5LSaRjq6u03S5m1zkZRc8n3q8bfad86FizqGC02m3e/Zh4kWTwnsO0pVW+mzeVSsBqDVT/g==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/cozy-flags/-/cozy-flags-2.7.2.tgz",
+      "integrity": "sha512-ZGuuVTiZXVlCEQ+ZWlpyCna4xb50qcgDMR7IuLd0n4O2XkUCkND6awjepGqq4F1/EE/ydZb4Zj2JGcLjUluxuQ==",
       "requires": {
         "microee": "^0.0.6"
       }
@@ -7517,6 +7527,14 @@
         "qs": "^6.7.0"
       },
       "dependencies": {
+        "cozy-flags": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/cozy-flags/-/cozy-flags-2.7.1.tgz",
+          "integrity": "sha512-TtVhuyMSRADRr4q5LSaRjq6u03S5m1zkZRc8n3q8bfad86FizqGC02m3e/Zh4kWTwnsO0pVW+mzeVSsBqDVT/g==",
+          "requires": {
+            "microee": "^0.0.6"
+          }
+        },
         "qs": {
           "version": "6.10.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "browser-hrtime": "^1.1.8",
     "cozy-client": "^23.15.0",
     "cozy-doctypes": "^1.82.2",
+    "cozy-flags": "^2.7.2",
     "cozy-keys-lib": "^3.9.0",
     "cozy-ui": "^51.2.0",
     "date-fns": "^1.30.1",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -85,7 +85,8 @@ const SyncInterval = 6 * 60 * 60 * 1000; // 6 hours
         <ng-template #exportVault></ng-template>
         <ng-template #appPasswordGenerator></ng-template>
         <router-outlet></router-outlet>
-        <app-icon-sprite></app-icon-sprite>`,
+        <app-icon-sprite></app-icon-sprite>
+        <app-flag-switcher></app-flag-switcher>`,
 })
 export class AppComponent implements OnInit {
     @ViewChild('settings', { read: ViewContainerRef, static: true }) settingsRef: ViewContainerRef;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -66,6 +66,8 @@ import { IconSpriteComponent } from '../cozy/wrappers/icon-sprite/icon-sprite.co
 import { ImportPageComponent } from '../cozy/wrappers/import-page/import-page.component';
 import { InstallationPageComponent } from '../cozy/wrappers/installation-page/installation-page.component';
 
+import { FlagSwitcherComponent } from '../cozy/wrappers/flag-switcher/flag-switcher.component';
+
 import { AddEditComponent as SendAddEditComponent } from './send/add-edit.component';
 import { SendComponent } from './send/send.component';
 
@@ -218,6 +220,9 @@ registerLocaleData(localeZhTw, 'zh-TW');
         IconSpriteComponent,
         ButtonExtensionComponent,
         CozyIconComponent,
+        FlagSwitcherComponent,
+        FlagConditionnalComponent,
+        IfFlagDirective,
     ],
     entryComponents: [
         AttachmentsComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -66,6 +66,8 @@ import { IconSpriteComponent } from '../cozy/wrappers/icon-sprite/icon-sprite.co
 import { ImportPageComponent } from '../cozy/wrappers/import-page/import-page.component';
 import { InstallationPageComponent } from '../cozy/wrappers/installation-page/installation-page.component';
 
+import { FlagConditionalComponent } from '../cozy/components/flag-conditional/flag-conditional.component';
+import { IfFlagDirective } from '../cozy/components/flag-conditional/if-flag.directive';
 import { FlagSwitcherComponent } from '../cozy/wrappers/flag-switcher/flag-switcher.component';
 
 import { AddEditComponent as SendAddEditComponent } from './send/add-edit.component';
@@ -221,7 +223,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         ButtonExtensionComponent,
         CozyIconComponent,
         FlagSwitcherComponent,
-        FlagConditionnalComponent,
+        FlagConditionalComponent,
         IfFlagDirective,
     ],
     entryComponents: [

--- a/src/cozy/components/flag-conditional/flag-conditional.component.html
+++ b/src/cozy/components/flag-conditional/flag-conditional.component.html
@@ -1,0 +1,1 @@
+<ng-content *ngIf="isFlagEnabled"></ng-content>

--- a/src/cozy/components/flag-conditional/flag-conditional.component.ts
+++ b/src/cozy/components/flag-conditional/flag-conditional.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+// @ts-ignore
+import flag from 'cozy-flags';
+
+/**
+ * A component that renders its children only if the correct flag is set to TRUE
+ *
+ * usage: <app-flag-conditional flagname="some.flag.name"></app-flag-conditional>
+ */
+@Component({
+    selector: 'app-flag-conditional',
+    templateUrl: './flag-conditional.component.html',
+    encapsulation: ViewEncapsulation.None,
+})
+export class FlagConditionalComponent implements OnInit, OnDestroy {
+    @Input() flagname: string;
+
+    isFlagEnabled = false;
+
+    ngOnDestroy(): void {
+        flag.store.removeListener('change', this.flagChanged.bind(this));
+    }
+
+    ngOnInit() {
+        flag.store.on('change', this.flagChanged.bind(this));
+
+        this.flagChanged();
+    }
+
+    flagChanged() {
+        this.isFlagEnabled = flag(this.flagname);
+    }
+}

--- a/src/cozy/components/flag-conditional/if-flag.directive.ts
+++ b/src/cozy/components/flag-conditional/if-flag.directive.ts
@@ -1,0 +1,47 @@
+import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
+// @ts-ignore
+import flag from 'cozy-flags';
+
+/**
+ * A directive that allows to render a component only if the correct flag is set to TRUE
+ *
+ * usage: <div *ifFlag="some.flag.name"></div>
+ */
+@Directive({ selector: '[ifFlag]'})
+export class IfFlagDirective implements OnInit, OnDestroy {
+  private isFlagEnabled = false;
+  private hasView = false;
+  private flagName: string;
+
+  @Input() set ifFlag(flagName: string) {
+    this.flagName = flagName;
+    this.flagChanged();
+  }
+
+  constructor(
+    private templateRef: TemplateRef<any>,
+    private viewContainer: ViewContainerRef
+  ) { }
+
+  ngOnDestroy(): void {
+      flag.store.removeListener('change', this.flagChanged.bind(this));
+  }
+
+  ngOnInit() {
+      flag.store.on('change', this.flagChanged.bind(this));
+
+      this.flagChanged();
+  }
+
+  flagChanged() {
+      this.isFlagEnabled = flag(this.flagName);
+
+      if (this.isFlagEnabled && !this.hasView) {
+          this.viewContainer.createEmbeddedView(this.templateRef);
+          this.hasView = true;
+      } else if (!this.isFlagEnabled && this.hasView) {
+          this.viewContainer.clear();
+          this.hasView = false;
+      }
+  }
+}

--- a/src/cozy/flags.ts
+++ b/src/cozy/flags.ts
@@ -1,0 +1,1 @@
+export const FORCE_VAULT_UNCONFIGURED = 'passwords.force-vault-unconfigured';

--- a/src/cozy/services/cozy-client.service.ts
+++ b/src/cozy/services/cozy-client.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import CozyClient from 'cozy-client';
+// @ts-ignore
+import flag from 'cozy-flags';
 
 class StaticCozyClient {
     static client: CozyClient = undefined;
@@ -12,6 +14,7 @@ export class CozyClientService {
     GetClient(): CozyClient {
         if (StaticCozyClient.client === undefined) {
             StaticCozyClient.client = CozyClient.fromDOM();
+            StaticCozyClient.client.registerPlugin(flag.plugin, undefined);
         }
 
         return StaticCozyClient.client;

--- a/src/cozy/services/installation-guard.service.ts
+++ b/src/cozy/services/installation-guard.service.ts
@@ -7,6 +7,10 @@ import {
 import { MessagingService } from '../../../jslib/src/abstractions/messaging.service';
 import { CozyClientService } from './cozy-client.service';
 
+// @ts-ignore
+import flag from 'cozy-flags';
+import { FORCE_VAULT_UNCONFIGURED } from '../flags';
+
 @Injectable({ providedIn: 'root' })
 export class VaultInstallationService {
     userFinishedInstallation = false;
@@ -21,7 +25,7 @@ export class VaultInstallationService {
             []
         );
 
-        return vault.extension_installed || this.userFinishedInstallation;
+        return !flag(FORCE_VAULT_UNCONFIGURED) && (vault.extension_installed || this.userFinishedInstallation);
     }
 
     setIsInstalled() {

--- a/src/cozy/wrappers/flag-switcher/flag-switcher.component.ts
+++ b/src/cozy/wrappers/flag-switcher/flag-switcher.component.ts
@@ -1,0 +1,32 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { AngularWrapperComponent } from '../angular-wrapper.component';
+
+// @ts-ignore
+import flag from 'cozy-flags';
+// @ts-ignore
+import FlagSwitcher from 'cozy-flags/dist/FlagSwitcher';
+
+@Component({
+    selector: 'app-flag-switcher',
+    templateUrl: '../angular-wrapper.component.html',
+    encapsulation: ViewEncapsulation.None,
+})
+export class FlagSwitcherComponent extends AngularWrapperComponent {
+
+    /**********/
+    /* Render */
+    /**********/
+
+    protected async renderReact() {
+        if (process.env.NODE_ENV === 'development') {
+            flag('switcher', true);
+        }
+
+        ReactDOM.render(
+            React.createElement(FlagSwitcher),
+            this.getRootDomNode()
+        );
+    }
+}

--- a/webpack.browser.js
+++ b/webpack.browser.js
@@ -60,6 +60,11 @@ const common = {
                 './manifest.webapp',
             ]
         }),
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': process.env.DEVELOPMENT === '1'
+                ? JSON.stringify('development')
+                : JSON.stringify('production'),
+        })
     ],
     resolve: {
         extensions: ['.tsx', '.ts', '.js', '.jsx'],
@@ -94,7 +99,7 @@ const common = {
 };
 
 const renderer = {
-    mode: process.env.DEVELOPMENT ? 'development' :'production',
+    mode: process.env.DEVELOPMENT === '1' ? 'development' : 'production',
     devtool: false,
     target: 'web',
     node: {
@@ -104,7 +109,7 @@ const renderer = {
         'app/main': './src/app/main.ts',
     },
     optimization: {
-        minimize: process.env.DEVELOPMENT ? true : false,
+        minimize: process.env.DEVELOPMENT === '1' ? false : true,
         splitChunks: {
             cacheGroups: {
                 commons: {


### PR DESCRIPTION
Add flags support to `cozy-pass-web`

This will allow components imported from `cozy-passwords` to be able to read flags states : 
- `passwords.force-unsupported-platform` (used by installation 1st step)
- `passwords.oidc-auth` (used by installation 2nd step)
- `passwords.force-no-hint` (used by installation 3rd step)
- `passwords.force-vault-configured`(used by installation 2nd step when `passwords.oidc-auth` is `true`)

The following flag has been re-implemented on Angular router side :
- `passwords.force-vault-unconfigured` (used to force installation screen)

FlagSwitcher component has been inserted in the app. In order to display it or not based on DEV environment, I had to fix the webpack configuration

`FlagConditionalComponent` and `IfFlagDirective` are not used yet but will be useful for future WIP features. This will be used by the Sharing feature.