### PR TITLE
feat: rework ReactWrapper props

### DIFF
--- a/src/cozy/wrappers/button-extension/button-extension.component.ts
+++ b/src/cozy/wrappers/button-extension/button-extension.component.ts
@@ -18,17 +18,11 @@ export class ButtonExtensionComponent extends AngularWrapperComponent {
     /* Props Bindings */
     /******************/
 
-    protected getProps(): AngularWrapperProps {
-        const data = {
-            extension_installed: false, // not used in this component
-        };
-
-        const client = this.clientService.GetClient();
+    protected async getProps(): Promise<AngularWrapperProps> {
+        const reactWrapperProps = await this.getReactWrapperProps();
 
         return {
-            client: client,
-            bitwardenData: data,
-            vaultData: this.getVaultData(),
+            reactWrapperProps: reactWrapperProps,
         };
     }
 
@@ -38,7 +32,7 @@ export class ButtonExtensionComponent extends AngularWrapperComponent {
 
     protected async renderReact() {
         ReactDOM.render(
-            React.createElement(ButtonExtension, this.getProps()),
+            React.createElement(ButtonExtension, await this.getProps()),
             this.getRootDomNode()
         );
     }

--- a/src/cozy/wrappers/button-extension/button-extension.jsx
+++ b/src/cozy/wrappers/button-extension/button-extension.jsx
@@ -8,7 +8,7 @@ import {
 import getSupportedPlatforms from 'cozy/react/supportedPlatforms';
 import { detect as detectBrowser } from 'detect-browser';
 import React from 'react';
-import ReactWrapper from '../react-wrapper';
+import ReactWrapper, { reactWrapperProps } from '../react-wrapper';
 
 const browser = detectBrowser();
 
@@ -43,7 +43,7 @@ const ButtonClient = (props) => {
 };
 
 // wrap original UIButtonClient component
-const ImportPageWrapper = ({ client, bitwardenData, ...props }) => {
+const ButtonExtensionWrapper = ({ reactWrapperProps, ...props }) => {
   const extensionStatus = useExtensionStatus();
 
   if (extensionStatus !== extensionStatuses.notInstalled) {
@@ -51,10 +51,14 @@ const ImportPageWrapper = ({ client, bitwardenData, ...props }) => {
   }
 
   return (
-    <ReactWrapper client={client} bitwardenData={bitwardenData} {...props}>
+    <ReactWrapper reactWrapperProps={reactWrapperProps}>
       <ButtonClient {...props}></ButtonClient>
     </ReactWrapper>
   );
 };
 
-export default ImportPageWrapper;
+ButtonExtensionWrapper.propTypes = {
+  reactWrapperProps: reactWrapperProps.isRequired
+}
+
+export default ButtonExtensionWrapper;

--- a/src/cozy/wrappers/import-page/import-page.component.ts
+++ b/src/cozy/wrappers/import-page/import-page.component.ts
@@ -16,17 +16,11 @@ export class ImportPageComponent extends AngularWrapperComponent {
     /* Props Bindings */
     /******************/
 
-    protected getProps(): AngularWrapperProps {
-        const data = {
-            extension_installed: true, // to be replaced with client fetch
-        };
-
-        const client = this.clientService.GetClient();
+    protected async getProps(): Promise<AngularWrapperProps> {
+        const reactWrapperProps = await this.getReactWrapperProps();
 
         return {
-            client: client,
-            bitwardenData: data,
-            vaultData: this.getVaultData(),
+            reactWrapperProps: reactWrapperProps,
         };
     }
 
@@ -34,9 +28,9 @@ export class ImportPageComponent extends AngularWrapperComponent {
     /* Render */
     /**********/
 
-    protected renderReact() {
+    protected async renderReact() {
         ReactDOM.render(
-            React.createElement(ImportPage, this.getProps()),
+            React.createElement(ImportPage, await this.getProps()),
             this.getRootDomNode()
         );
     }

--- a/src/cozy/wrappers/import-page/import-page.jsx
+++ b/src/cozy/wrappers/import-page/import-page.jsx
@@ -1,14 +1,18 @@
 import React from "react";
 import ImportPage from "../../react/components/ImportPage";
-import ReactWrapper from "../react-wrapper";
+import ReactWrapper, { reactWrapperProps } from "../react-wrapper";
 
 // wrap original ImportPage component into
-const ImportPageWrapper = ({ client, bitwardenData, ...props }) => {
+const ImportPageWrapper = ({ reactWrapperProps }) => {
   return (
-    <ReactWrapper client={client} bitwardenData={bitwardenData} {...props}>
+    <ReactWrapper reactWrapperProps={reactWrapperProps}>
       <ImportPage></ImportPage>
     </ReactWrapper>
   );
 };
+
+ImportPageWrapper.propTypes = {
+  reactWrapperProps: reactWrapperProps.isRequired
+}
 
 export default ImportPageWrapper;

--- a/src/cozy/wrappers/installation-page/installation-page.component.ts
+++ b/src/cozy/wrappers/installation-page/installation-page.component.ts
@@ -74,38 +74,17 @@ export class InstallationPageComponent extends AngularWrapperComponent {
     /* Props Bindings */
     /******************/
 
-    protected async fetchHintExists(client: CozyClient) {
-        try {
-            await client
-                .getStackClient()
-                .collection('io.cozy.settings')
-                .get('hint');
-
-            return true;
-        } catch (e) {
-            return false;
-        }
-    }
-
     protected onSkipExtension() {
         this.vaultInstallationService.setIsInstalled();
         this.messagingService.send('installed');
     }
 
     protected async getProps(): Promise<InstallationPageProps> {
-        const client = this.clientService.GetClient();
-
-        const hasHint = await this.fetchHintExists(client);
-
-        const bitwardenData = {
-            extension_installed: hasHint,
-        };
+        const reactWrapperProps = await this.getReactWrapperProps(true);
 
         return {
-            client: client,
-            bitwardenData: bitwardenData,
+            reactWrapperProps: reactWrapperProps,
             onSkipExtension: this.onSkipExtension.bind(this),
-            vaultData: this.getVaultData(),
         };
     }
 

--- a/src/cozy/wrappers/installation-page/installation-page.jsx
+++ b/src/cozy/wrappers/installation-page/installation-page.jsx
@@ -1,23 +1,23 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import InstallationPage from '../../react/components/InstallationPage';
-import ReactWrapper from '../react-wrapper';
+import ReactWrapper, { reactWrapperProps } from '../react-wrapper';
 
 // wrap original InstallationPage component
 const InstallationPageWrapper = ({
-  client,
-  bitwardenData,
-  onSkipExtension,
-  ...props
+  reactWrapperProps,
+  onSkipExtension
 }) => {
   return (
-    <ReactWrapper
-      client={client}
-      bitwardenData={bitwardenData}
-      {...props}
-    >
+    <ReactWrapper reactWrapperProps={reactWrapperProps}>
       <InstallationPage onSkipExtension={onSkipExtension}></InstallationPage>
     </ReactWrapper>
   );
 };
+
+InstallationPageWrapper.propTypes = {
+  reactWrapperProps: reactWrapperProps.isRequired,
+  onSkipExtension: PropTypes.func.isRequired,
+}
 
 export default InstallationPageWrapper;

--- a/src/cozy/wrappers/react-wrapper.jsx
+++ b/src/cozy/wrappers/react-wrapper.jsx
@@ -7,8 +7,35 @@ import { VaultProvider } from "cozy-keys-lib";
 import { BreakpointsProvider } from "cozy-ui/transpiled/react/hooks/useBreakpoints";
 import { I18n } from "cozy-ui/transpiled/react/I18n";
 import React from "react";
+import PropTypes from 'prop-types';
 import { BitwardenSettingsContext } from "../react/bitwarden-settings";
 import { HashRouter } from "react-router-dom";
+
+const bitwardenDataProps = PropTypes.shape({
+  extension_installed: PropTypes.bool.isRequired
+});
+
+const vaultDataProps = PropTypes.shape({
+  apiService: PropTypes.object.isRequired,
+  environmentService: PropTypes.object.isRequired,
+  authService: PropTypes.object.isRequired,
+  syncService: PropTypes.object.isRequired,
+  cryptoService: PropTypes.object.isRequired,
+  cipherService: PropTypes.object.isRequired,
+  userService: PropTypes.object.isRequired,
+  collectionService: PropTypes.object.isRequired,
+  passwordGenerationService: PropTypes.object.isRequired,
+  vaultTimeoutService: PropTypes.object.isRequired,
+  containerService: PropTypes.object.isRequired,
+  importService: PropTypes.object.isRequired,
+  utils: PropTypes.func.isRequired
+});
+
+export const reactWrapperProps = PropTypes.shape({
+  client: PropTypes.object.isRequired,
+  bitwardenData: bitwardenDataProps.isRequired,
+  vaultData: vaultDataProps.isRequired
+})
 
 /* 
 With MUI V4, it is possible to generate deterministic class names. 
@@ -24,11 +51,11 @@ const generateClassName = createGenerateClassName({
 
 // wrap a component in all needed providers
 const ReactWrapper = ({
-  client,
-  bitwardenData,
-  vaultData,
+  reactWrapperProps,
   ...props
 }) => {
+  const { client, bitwardenData, vaultData } = reactWrapperProps;
+
   const appLocale = client.getInstanceOptions().locale ?? 'en';
 
   return (
@@ -52,5 +79,9 @@ const ReactWrapper = ({
     </StylesProvider>
   );
 };
+
+ReactWrapper.propTypes = {
+  reactWrapperProps: reactWrapperProps.isRequired
+}
 
 export default ReactWrapper;


### PR DESCRIPTION
`ReactWrapper` props have been merged in a single `reactWrapperProps`
prop

This makes easier to instantiate needed props from
`angular-wrapper.component` and all inherited components. Therefore
those will be easier to maintain

Also `ReactWrapper` prop-types are now more complete