### PR TITLE
Feat/move cipher org

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -377,7 +377,7 @@
                     <div class="right">
                         <ng-container *ifFlag="CAN_SHARE_ORGANIZATION">
                         <button appBlurClick type="button" (click)="share()" appA11yTitle="{{'shareItem' | i18n}}"
-                            *ngIf="editMode && cipher && !cipher.organizationId && !cloneMode">
+                            *ngIf="editMode && cipher && !cloneMode">
                             <i class="fa fa-share-alt fa-lg fa-fw" aria-hidden="true"></i>
                         </button>
                         </ng-container>

--- a/src/app/vault/share.component.ts
+++ b/src/app/vault/share.component.ts
@@ -33,6 +33,14 @@ export class ShareComponent extends BaseShareComponent {
         });
     }
 
+    async load() {
+        await super.load();
+
+        if (this.cipher.organizationId) {
+            this.selectedCollectionId = this.collections.find(col => col.organizationId === this.cipher.organizationId)?.id;
+        }
+    }
+
     async submit(): Promise<boolean> {
         const selectedCollection = this.collections
             .filter(c => !!(c as any).checked);


### PR DESCRIPTION
This PR allow to move a cipher from an organization to another one using the existing `share` modal (the one from Bitwarden code, not from cozy-sharing)