### PR TITLE
Feat/sync organization

### DIFF
--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -90,6 +90,7 @@ import { PasswordRepromptService } from 'jslib/services/passwordReprompt.service
 import { CozyClientService } from '../cozy/services/cozy-client.service';
 import { VaultInstallationService, VaultInstalledGuardService, VaultUninstalledGuardService } from '../cozy/services/installation-guard.service';
 
+const clientService = new CozyClientService();
 const logService = new ElectronLogService();
 const i18nService = new I18nService(window.navigator.language, './locales');
 const stateService = new StateService();
@@ -124,7 +125,7 @@ const vaultTimeoutService = new VaultTimeoutService(cipherService, folderService
     null, async () => messagingService.send('logout', { expired: false }));
 const syncService = new SyncService(userService, apiService, settingsService,
     folderService, cipherService, cryptoService, collectionService, storageService, messagingService, policyService,
-    sendService, async (expired: boolean) => messagingService.send('logout', { expired: expired }), tokenService);
+    sendService, async (expired: boolean) => messagingService.send('logout', { expired: expired }), tokenService, clientService);
 const passwordGenerationService = new PasswordGenerationService(cryptoService, storageService, policyService);
 const totpService = new TotpService(storageService, cryptoFunctionService);
 const containerService = new ContainerService(cryptoService);
@@ -197,7 +198,7 @@ export function initFactory(): Function {
         VaultInstallationService,
         VaultInstalledGuardService,
         VaultUninstalledGuardService,
-        CozyClientService,
+        { provide: CozyClientService, useValue: clientService },
         { provide: AuditServiceAbstraction, useValue: auditService },
         { provide: AuthServiceAbstraction, useValue: authService },
         { provide: CipherServiceAbstraction, useValue: cipherService },

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -23,13 +23,13 @@ export class CryptoService extends CryptoServiceBase {
             this.localStorageService = storageService;
     }
 
-    async upsertOrganizationKey(organization: ProfileOrganizationResponse) {
-        if (organization.key === '') {
+    async upsertOrganizationKey(organizationId: string, key: string) {
+        if (key === '') {
             return;
         }
         const encOrgKeys = await this.localStorageService.get<any>(Keys.encOrgKeys);
 
-        encOrgKeys[organization.id] = organization.key;
+        encOrgKeys[organizationId] = key;
 
         await this.clearOrgKeys();
         await this.localStorageService.save(Keys.encOrgKeys, encOrgKeys);

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -128,10 +128,6 @@ export class SyncService extends SyncServiceBase {
     }
 
     protected async syncUpsertOrganization(organizationId: string, isEdit: boolean) {
-        if (isEdit) {
-            return;
-        }
-
         if (!organizationId) {
             return;
         }


### PR DESCRIPTION
This PR improve organization synchronization

When receiving a cipher after the 2nd confirmation steps we now correctly retrieve the organization's key and the application now displays the organization without having to refresh the application (this only works when receiving a cipher, there is still no realtime mechanism on organization events)

When receiving a cipher update, we now tries to synchronize the organization to cover the case where the cipher has been moved from one organization to another (also this prevent a bug from current stack's implementation which send a update event even for a cipher creation)

