### PR TITLE
Fix/OIDC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7438,9 +7438,9 @@
       "integrity": "sha512-laIL/ATYV9oZnmqS+LMoO9qzk8XjJ1v2/YrA1Po2rI8ia/MDgjYO07424x2RuvHhNOBPGjD+JmqwQ0rNDlLW+Q=="
     },
     "cozy-keys-lib": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/cozy-keys-lib/-/cozy-keys-lib-3.9.0.tgz",
-      "integrity": "sha512-bjNjcsa2OHL6H2BMiOymaHNCk2UbKJq6J17T0fhBB8kJ9xtY8M4xjbe/PVmrZOyZgvXYWJmCHaVgDFjA43rdcw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/cozy-keys-lib/-/cozy-keys-lib-3.9.1.tgz",
+      "integrity": "sha512-wPpJUZAGGZAeTJwiW2/PGARZoB9dDffkPsJLMrSr1pqIhXxFfqPmTiyqHYsIXR5eJ18UeFRXMQJQCm3QkP07jQ==",
       "requires": {
         "@aspnet/signalr": "^1.1.4",
         "@aspnet/signalr-protocol-msgpack": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7368,9 +7368,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cozy-client": {
-      "version": "23.19.1",
-      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-23.19.1.tgz",
-      "integrity": "sha512-tdu+3840xilc5cvn/CTf1OKrAq1gUzSGRCpue+AF5F2M/jdSE3NxThA6vE9OpTV9MEhazAYWvzrVshqljpUh+Q==",
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-24.3.3.tgz",
+      "integrity": "sha512-gamm3Qq9QpW3jXiWOgqgZbUlHcP0ush7wtrBvg75pikKD8jfQ8hr/OJ/O6CrNb+c6q/8ck0dHwX/n55I0phDDQ==",
       "requires": {
         "@cozy/minilog": "1.0.0",
         "@types/jest": "^26.0.20",
@@ -7379,7 +7379,7 @@
         "cozy-device-helper": "^1.12.0",
         "cozy-flags": "2.7.1",
         "cozy-logger": "^1.6.0",
-        "cozy-stack-client": "^23.19.0",
+        "cozy-stack-client": "^24.3.3",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.13",
         "microee": "^0.0.6",
@@ -7561,9 +7561,9 @@
       }
     },
     "cozy-stack-client": {
-      "version": "23.19.0",
-      "resolved": "https://registry.npmjs.org/cozy-stack-client/-/cozy-stack-client-23.19.0.tgz",
-      "integrity": "sha512-oq7/ERKy/Gg3jnxSi0rs3upvBccsGmmfdMiIa9hhJcw/Vxl7NMmjUM2itPnfmBNAMfBax6VlB8HWI1LY87fLuw==",
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/cozy-stack-client/-/cozy-stack-client-24.3.3.tgz",
+      "integrity": "sha512-zv0W3LZjrUrYpCcsMyCq1LUOk+rAf1ZHZt44pGR67hcLana3RQrOi94wHBrD3SsUV+XIvZTzLIS+yI64v5Y0Iw==",
       "requires": {
         "cozy-flags": "2.7.1",
         "detect-node": "^2.0.4",
@@ -13876,9 +13876,9 @@
       "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc="
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
     },
     "node-forge": {
       "version": "0.10.0",
@@ -15817,9 +15817,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
-      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
+      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "angular2-toaster": "^11.0.1",
     "big-integer": "1.6.48",
     "browser-hrtime": "^1.1.8",
-    "cozy-client": "^23.19.1",
+    "cozy-client": "^24.3.3",
     "cozy-doctypes": "^1.82.2",
     "cozy-flags": "^2.7.2",
     "cozy-keys-lib": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "cozy-client": "^23.19.1",
     "cozy-doctypes": "^1.82.2",
     "cozy-flags": "^2.7.2",
-    "cozy-keys-lib": "^3.9.0",
+    "cozy-keys-lib": "^3.9.1",
     "cozy-realtime": "^3.13.0",
     "cozy-sharing": "3.6.0",
     "cozy-ui": "^51.5.0",

--- a/src/cozy/react/components/passphrase-utils.js
+++ b/src/cozy/react/components/passphrase-utils.js
@@ -104,13 +104,17 @@ export const forceSetVaultPassphrase = async (
   vaultClient,
   passphrase
 ) => {
-  const {
+  let {
     Kdf: kdf,
     KdfIterations: kdfIterations
   } = await client.stackClient.fetchJSON(
     'POST',
     '/bitwarden/api/accounts/prelogin'
   )
+
+  if (kdfIterations === 0) {
+    kdfIterations = 100000;
+  }
 
   const masterKey = await vaultClient.computeMasterKey(
     passphrase,

--- a/src/cozy/react/helpers/generateWebAppLink.js
+++ b/src/cozy/react/helpers/generateWebAppLink.js
@@ -2,11 +2,11 @@ import { generateWebLink } from 'cozy-ui/transpiled/react/AppLinker'
 
 const generateWebAppLink = (slug, client) => {
   const cozyURL = new URL(client.getStackClient().uri)
-  const { cozySubdomainType } = client.getInstanceOptions()
+  const { subdomain } = client.getInstanceOptions()
   const link = generateWebLink({
     cozyUrl: cozyURL.origin,
     slug,
-    subDomainType: cozySubdomainType
+    subDomainType: subdomain
   })
 
   return link

--- a/src/cozy/services/installation-guard.service.ts
+++ b/src/cozy/services/installation-guard.service.ts
@@ -18,14 +18,18 @@ export class VaultInstallationService {
     constructor(private clientService: CozyClientService) {}
 
     async IsVaultInstalled(): Promise<boolean> {
-        const client = this.clientService.GetClient();
-        const vault = await client.stackClient.fetchJSON(
-            'GET',
-            '/data/io.cozy.settings/io.cozy.settings.bitwarden',
-            []
-        );
+        try {
+            const client = this.clientService.GetClient();
+            const vault = await client.stackClient.fetchJSON(
+                'GET',
+                '/data/io.cozy.settings/io.cozy.settings.bitwarden',
+                []
+            );
 
-        return !flag(FORCE_VAULT_UNCONFIGURED) && (vault.extension_installed || this.userFinishedInstallation);
+            return !flag(FORCE_VAULT_UNCONFIGURED) && (vault.extension_installed || this.userFinishedInstallation);
+        } catch {
+            return false;
+        }
     }
 
     setIsInstalled() {

--- a/src/cozy/wrappers/angular-wrapper.component.ts
+++ b/src/cozy/wrappers/angular-wrapper.component.ts
@@ -117,7 +117,9 @@ export class AngularWrapperComponent
     async getReactWrapperProps(checkExtensionInstalled = false): Promise<ReactWrapperProps> {
         const client = this.clientService.GetClient();
 
-        const hasHint = checkExtensionInstalled ? true : await this.fetchHintExists(client);
+        const hasHint = checkExtensionInstalled
+            ? await this.fetchHintExists(client)
+            : true;
 
         const bitwardenData = {
             extension_installed: hasHint,


### PR DESCRIPTION
This PR fixes the following OIDC installation related bugs:
- It is now possible to set passwords's Hint on step 3 after setting a password on step 2 (cozyClient.refreshToken now works correctly)
- The `UPDATE COZY PASS PASSWORD` button now correctly generates url depending on `nested`/`flat` domain type
- It is now possible to access installation page if `io.cozy.settings.bitwarden` document is missing
- Fix on `extension_installed` state that was broken by previous refactoring 6bb611bb5f356cce08c5356fd26b5f789fc6dee8