### PR TITLE
feat: replace `cozy-cloud` icon by `share` icon on shared ciphers

### DIFF
--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -18,7 +18,7 @@
                     <span class="text">
                         {{c.name}}
                         <ng-container *ngIf="c.organizationId">
-                            <i class="icon-cozy icon-cozy-sync" title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <app-cozy-icon ref="share" width="16" height="16" title="{{'shared' | i18n}}"></app-cozy-icon>
                             <span class="sr-only">{{'shared' | i18n}}</span>
                         </ng-container>
                         <ng-container *ngIf="c.hasAttachments">

--- a/src/scss/cozy.scss
+++ b/src/scss/cozy.scss
@@ -78,7 +78,7 @@ app-vault-groupings {
         margin-right: 5px;
 
         svg {
-            fill: var(--coolGrey);
+            fill: var(--secondaryTextColor);
         }
     }
 }

--- a/src/scss/cozy.scss
+++ b/src/scss/cozy.scss
@@ -82,3 +82,11 @@ app-vault-groupings {
         }
     }
 }
+
+app-vault-ciphers {
+    app-cozy-icon {
+        svg {
+            fill: var(--secondaryTextColor);
+        }
+    }
+}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1884255/132735735-7a7ce0cc-6921-4db1-9cc6-7f8f9f3d8903.png)

After:
![image](https://user-images.githubusercontent.com/1884255/132735826-ca478ab5-267c-443c-ab64-5575db0b6fca.png)
