### PR TITLE
Feat/realtime orgs delete

### DIFF
--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -35,7 +35,6 @@ import { EventService } from 'jslib/services/event.service';
 import { ExportService } from 'jslib/services/export.service';
 import { FileUploadService } from 'jslib/services/fileUpload.service';
 import { FolderService } from 'jslib/services/folder.service';
-import { NotificationsService } from 'jslib/services/notifications.service';
 import { PasswordGenerationService } from 'jslib/services/passwordGeneration.service';
 import { PolicyService } from 'jslib/services/policy.service';
 import { SearchService } from 'jslib/services/search.service';
@@ -49,6 +48,7 @@ import { VaultTimeoutService } from 'jslib/services/vaultTimeout.service';
 import { WebCryptoFunctionService } from 'jslib/services/webCryptoFunction.service';
 import { CipherService } from '../services/cipher.service';
 import { CryptoService } from '../services/crypto.service';
+import { NotificationsService } from '../services/notifications.service';
 import { SyncService } from '../services/sync.service';
 import { UserService } from '../services/user.service';
 
@@ -134,7 +134,7 @@ const authService = new AuthService(cryptoService, apiService, userService, toke
 const exportService = new ExportService(folderService, cipherService, apiService, cryptoService);
 const auditService = new AuditService(cryptoFunctionService, apiService);
 const notificationsService = new NotificationsService(userService, syncService, appIdService,
-    apiService, vaultTimeoutService, async () => messagingService.send('logout', { expired: true }), logService);
+    apiService, vaultTimeoutService, async () => messagingService.send('logout', { expired: true }), logService, clientService, broadcasterService);
 const environmentService = new EnvironmentService(apiService, storageService, notificationsService);
 const eventService = new EventService(storageService, apiService, userService, cipherService);
 const systemService = new SystemService(storageService, vaultTimeoutService, messagingService, platformUtilsService,
@@ -215,6 +215,7 @@ export function initFactory(): Function {
         { provide: PasswordGenerationServiceAbstraction, useValue: passwordGenerationService },
         { provide: ApiServiceAbstraction, useValue: apiService },
         { provide: SyncServiceAbstraction, useValue: syncService },
+        { provide: SyncService, useValue: syncService },
         { provide: UserServiceAbstraction, useValue: userService },
         { provide: MessagingServiceAbstraction, useValue: messagingService },
         { provide: BroadcasterService, useValue: broadcasterService },

--- a/src/cozy/services/cozy-client.service.ts
+++ b/src/cozy/services/cozy-client.service.ts
@@ -3,10 +3,11 @@ import CozyClient from 'cozy-client';
 // @ts-ignore
 import flag from 'cozy-flags';
 // @ts-ignore
-import { RealtimePlugin } from 'cozy-realtime';
+import CozyRealTime, { RealtimePlugin } from 'cozy-realtime';
 
 class StaticCozyClient {
     static client: CozyClient = undefined;
+    static realtime: CozyRealTime = undefined;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -14,12 +15,26 @@ export class CozyClientService {
     private client: CozyClient = undefined;
 
     GetClient(): CozyClient {
+        this.InitClient();
+
+        return StaticCozyClient.client;
+    }
+
+    GetRealtime() : CozyRealTime {
+        this.InitClient();
+
+        return StaticCozyClient.realtime;
+    }
+
+    protected InitClient() {
         if (StaticCozyClient.client === undefined) {
             StaticCozyClient.client = CozyClient.fromDOM();
             StaticCozyClient.client.registerPlugin(flag.plugin, undefined);
             StaticCozyClient.client.registerPlugin(RealtimePlugin, undefined);
-        }
 
-        return StaticCozyClient.client;
+            StaticCozyClient.realtime = new CozyRealTime({
+                client: StaticCozyClient.client,
+            });
+        }
     }
 }

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -1,0 +1,54 @@
+import { ApiService } from 'jslib/abstractions/api.service';
+import { AppIdService } from 'jslib/abstractions/appId.service';
+import { EnvironmentService } from 'jslib/abstractions/environment.service';
+import { LogService } from 'jslib/abstractions/log.service';
+import { SyncService } from '../services/sync.service';
+import { UserService } from 'jslib/abstractions/user.service';
+import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
+
+import { CozyClientService } from '../cozy/services/cozy-client.service';
+
+import { NotificationsService as NotificationsServiceBase } from 'jslib/services/notifications.service';
+
+export class NotificationsService extends NotificationsServiceBase {
+    constructor(userService: UserService, private localSyncService: SyncService,
+        appIdService: AppIdService, apiService: ApiService,
+        vaultTimeoutService: VaultTimeoutService,
+        logoutCallback: () => Promise<void>, logService: LogService,
+        private clientService: CozyClientService) {
+            super(
+                userService,
+                localSyncService,
+                appIdService,
+                apiService,
+                vaultTimeoutService,
+                logoutCallback,
+                logService
+            );
+    }
+
+    async init(environmentService: EnvironmentService): Promise<void> {
+        await super.init(environmentService);
+
+        const realtime = this.clientService.GetRealtime();
+        realtime.unsubscribeAll();
+
+        const organizationDoctype = 'com.bitwarden.organizations';
+
+        await realtime.subscribe('deleted', organizationDoctype, this.handleOrganizationDelete.bind(this));
+        await realtime.subscribe('updated', organizationDoctype, this.handleOrganizationUpdate.bind(this));
+        await realtime.subscribe('created', organizationDoctype, this.handleOrganizationCreate.bind(this));
+    }
+
+    async handleOrganizationDelete(organization: any) {
+        await this.localSyncService.syncDeleteOrganization(organization._id);
+    }
+
+    async handleOrganizationCreate(organization: any) {
+        await this.localSyncService.syncUpsertOrganization(organization._id, false);
+    }
+
+    async handleOrganizationUpdate(organization: any) {
+        await this.localSyncService.syncUpsertOrganization(organization._id, false);
+    }
+}

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -75,11 +75,23 @@ export class NotificationsService extends NotificationsServiceBase {
 
     async handleOrganizationCreate(organization: any) {
         await this.waitForSyncCompleted();
-        await this.localSyncService.syncUpsertOrganization(organization._id, false);
+
+        // Hack: syncUpsertOrganization has been replaced by a fullSync until we find a way
+        // to synchronize cipher created before the sharing was initialized
+        //
+        // to remove hack, uncomment following line and delete fullSync call
+        // await this.localSyncService.syncUpsertOrganization(organization._id, false);
+        await this.localSyncService.fullSync(organization._id, false);
     }
 
     async handleOrganizationUpdate(organization: any) {
         await this.waitForSyncCompleted();
-        await this.localSyncService.syncUpsertOrganization(organization._id, false);
+
+        // Hack: syncUpsertOrganization has been replaced by a fullSync until we find a way
+        // to synchronize cipher created before the sharing was initialized
+        //
+        // to remove hack, uncomment following line and delete fullSync call
+        // await this.localSyncService.syncUpsertOrganization(organization._id, false);
+        await this.localSyncService.fullSync(organization._id, false);
     }
 }

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -1,21 +1,27 @@
 import { ApiService } from 'jslib/abstractions/api.service';
 import { AppIdService } from 'jslib/abstractions/appId.service';
+import { BroadcasterService } from 'jslib/abstractions/broadcaster.service';
 import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { LogService } from 'jslib/abstractions/log.service';
-import { SyncService } from '../services/sync.service';
 import { UserService } from 'jslib/abstractions/user.service';
 import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
+
+import { SyncService } from '../services/sync.service';
 
 import { CozyClientService } from '../cozy/services/cozy-client.service';
 
 import { NotificationsService as NotificationsServiceBase } from 'jslib/services/notifications.service';
+
+import * as uuid from 'uuid';
+
+const BroadcasterSubscriptionId = 'NotificationsService';
 
 export class NotificationsService extends NotificationsServiceBase {
     constructor(userService: UserService, private localSyncService: SyncService,
         appIdService: AppIdService, apiService: ApiService,
         vaultTimeoutService: VaultTimeoutService,
         logoutCallback: () => Promise<void>, logService: LogService,
-        private clientService: CozyClientService) {
+        private clientService: CozyClientService, protected broadcasterService: BroadcasterService) {
             super(
                 userService,
                 localSyncService,
@@ -40,15 +46,40 @@ export class NotificationsService extends NotificationsServiceBase {
         await realtime.subscribe('created', organizationDoctype, this.handleOrganizationCreate.bind(this));
     }
 
+    /**
+     * Wait for the Bitwarden's synchronization to ends
+     * This allows to lower chances of collisions with sync from native notification service
+     */
+    async waitForSyncCompleted() {
+        if (!this.localSyncService.syncInProgress) {
+            return;
+        }
+
+        const listenerUUID = BroadcasterSubscriptionId + uuid.v1();
+        return new Promise<void>(resolve => {
+            this.broadcasterService.subscribe(listenerUUID, (message: any) => {
+                switch (message.command) {
+                    case 'syncCompleted':
+                        this.broadcasterService.unsubscribe(listenerUUID);
+                        resolve();
+                        break;
+                }
+            });
+        });
+    }
+
     async handleOrganizationDelete(organization: any) {
+        await this.waitForSyncCompleted();
         await this.localSyncService.syncDeleteOrganization(organization._id);
     }
 
     async handleOrganizationCreate(organization: any) {
+        await this.waitForSyncCompleted();
         await this.localSyncService.syncUpsertOrganization(organization._id, false);
     }
 
     async handleOrganizationUpdate(organization: any) {
+        await this.waitForSyncCompleted();
         await this.localSyncService.syncUpsertOrganization(organization._id, false);
     }
 }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -38,4 +38,19 @@ export class UserService extends UserServiceBase {
 
         await this.localStorageService.save(Keys.organizationsPrefix + userId, organizationsData);
     }
+
+    async deleteOrganization(organizationId: string) {
+        const userId = await this.getUserId();
+
+        const oldOrganizations = await this.getAllOrganizations();
+
+        const newOrganizations = oldOrganizations.filter(organization => organization.id === organizationId);
+
+        const organizationsData: { [id: string]: OrganizationData; } = {};
+        newOrganizations.forEach(o => {
+            organizationsData[o.id] = o as OrganizationData;
+        });
+
+        await this.localStorageService.save(Keys.organizationsPrefix + userId, organizationsData);
+    }
 }


### PR DESCRIPTION
This PR introduces cozy-realtime mechanisms in the notification service

This allow to synchronize newly shared organizations between Alice and Bob, but also deleted organizations

Current implementation is not complete but is needed for the next demo

