### PR TITLE
feat: bump `cozy-client` version to 24.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7435,9 +7435,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cozy-client": {
-      "version": "24.3.3",
-      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-24.3.3.tgz",
-      "integrity": "sha512-gamm3Qq9QpW3jXiWOgqgZbUlHcP0ush7wtrBvg75pikKD8jfQ8hr/OJ/O6CrNb+c6q/8ck0dHwX/n55I0phDDQ==",
+      "version": "24.6.1",
+      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-24.6.1.tgz",
+      "integrity": "sha512-pW92TvOrFOXhz9lnZa/4PufW6UEAT7/PNupia2vFMY21sVP7OD0/f/qMTDQkZhyFkrb4n8gwCM5GTVmXdpMJ6w==",
       "requires": {
         "@cozy/minilog": "1.0.0",
         "@types/jest": "^26.0.20",
@@ -7446,7 +7446,7 @@
         "cozy-device-helper": "^1.12.0",
         "cozy-flags": "2.7.1",
         "cozy-logger": "^1.6.0",
-        "cozy-stack-client": "^24.3.3",
+        "cozy-stack-client": "^24.6.1",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.13",
         "microee": "^0.0.6",
@@ -7628,9 +7628,9 @@
       }
     },
     "cozy-stack-client": {
-      "version": "24.3.3",
-      "resolved": "https://registry.npmjs.org/cozy-stack-client/-/cozy-stack-client-24.3.3.tgz",
-      "integrity": "sha512-zv0W3LZjrUrYpCcsMyCq1LUOk+rAf1ZHZt44pGR67hcLana3RQrOi94wHBrD3SsUV+XIvZTzLIS+yI64v5Y0Iw==",
+      "version": "24.6.1",
+      "resolved": "https://registry.npmjs.org/cozy-stack-client/-/cozy-stack-client-24.6.1.tgz",
+      "integrity": "sha512-0pfxZxLh2o1LEqR2QiBiOuwEsPADmJCQUDA1+RsSK4rq67X2mFQ/mWLUIN3f+5KgUtRVHXQuKZODHs/xht/aTA==",
       "requires": {
         "cozy-flags": "2.7.1",
         "detect-node": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "angular2-toaster": "^11.0.1",
     "big-integer": "1.6.48",
     "browser-hrtime": "^1.1.8",
-    "cozy-client": "^24.3.3",
+    "cozy-client": "^24.6.1",
     "cozy-doctypes": "^1.82.2",
     "cozy-flags": "^2.7.2",
     "cozy-keys-lib": "^3.9.1",


### PR DESCRIPTION
`cozy-client` has been updated to `24.6.1` to retrieve a fix on how
sharing rules are generated for organization from cozy/cozy-client#1028