### PR TITLE
Feat/Disable edits actions in readonly collections

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -62,6 +62,7 @@ import { VaultComponent } from './vault/vault.component';
 import { ViewComponent } from './vault/view.component';
 
 import { ButtonExtensionComponent } from '../cozy/wrappers/button-extension/button-extension.component';
+import { ConfirmTrustedUsersComponent } from '../cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component';
 import { CozyIconComponent } from '../cozy/wrappers/cozy-icon/cozy-icon.component';
 import { IconSpriteComponent } from '../cozy/wrappers/icon-sprite/icon-sprite.component';
 import { ImportPageComponent } from '../cozy/wrappers/import-page/import-page.component';
@@ -229,6 +230,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         FlagConditionalComponent,
         IfFlagDirective,
         SharingComponent,
+        ConfirmTrustedUsersComponent,
     ],
     entryComponents: [
         AttachmentsComponent,

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -23,7 +23,6 @@ import { LockGuardService } from 'jslib/angular/services/lock-guard.service';
 import { UnauthGuardService } from 'jslib/angular/services/unauth-guard.service';
 import { ValidationService } from 'jslib/angular/services/validation.service';
 
-import { ApiService } from 'jslib/services/api.service';
 import { AppIdService } from 'jslib/services/appId.service';
 import { AuditService } from 'jslib/services/audit.service';
 import { AuthService } from 'jslib/services/auth.service';
@@ -46,6 +45,7 @@ import { TokenService } from 'jslib/services/token.service';
 import { TotpService } from 'jslib/services/totp.service';
 import { VaultTimeoutService } from 'jslib/services/vaultTimeout.service';
 import { WebCryptoFunctionService } from 'jslib/services/webCryptoFunction.service';
+import { ApiService } from '../services/api.service';
 import { CipherService } from '../services/cipher.service';
 import { CryptoService } from '../services/crypto.service';
 import { NotificationsService } from '../services/notifications.service';

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -89,6 +89,7 @@ import { PasswordRepromptService } from 'jslib/services/passwordReprompt.service
 
 import { CozyClientService } from '../cozy/services/cozy-client.service';
 import { VaultInstallationService, VaultInstalledGuardService, VaultUninstalledGuardService } from '../cozy/services/installation-guard.service';
+import { SharingService } from '../cozy/services/sharing.service';
 
 const clientService = new CozyClientService();
 const logService = new ElectronLogService();
@@ -108,6 +109,7 @@ const appIdService = new AppIdService(storageService);
 const apiService = new ApiService(tokenService, platformUtilsService,
     async (expired: boolean) => messagingService.send('logout', { expired: expired }));
 const userService = new UserService(tokenService, storageService, cryptoService);
+const sharingService = new SharingService(apiService, clientService, cryptoService, i18nService, platformUtilsService, userService);
 const settingsService = new SettingsService(userService, storageService);
 export let searchService: SearchService = null;
 const fileUploadService = new FileUploadService(logService, apiService);
@@ -199,6 +201,7 @@ export function initFactory(): Function {
         VaultInstalledGuardService,
         VaultUninstalledGuardService,
         { provide: CozyClientService, useValue: clientService },
+        { provide: SharingService, useValue: sharingService },
         { provide: AuditServiceAbstraction, useValue: auditService },
         { provide: AuthServiceAbstraction, useValue: authService },
         { provide: CipherServiceAbstraction, useValue: cipherService },

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -44,12 +44,12 @@
     </ng-container>
 </div>
 <div class="footer">
-    <button appBlurClick (click)="addCipher()" (contextmenu)="addCipherOptions()"
+    <button appBlurClick (click)="addCipher()" (contextmenu)="addCipherOptions()" *ngIf="!isReadOnly"
         class="block primary" appA11yTitle="{{'addItem' | i18n}}" [disabled]="deleted">
         <i class="fa fa-plus fa-lg" aria-hidden="true"></i>
     </button>
     <app-sharing *ngIf="collectionId" [collectionId]="collectionId"></app-sharing>
-    <button id="param-btn" (click)="openMenu()">
+    <button id="param-btn" (click)="openMenu()" *ngIf="!isReadOnly">
         <svg width="4" height="17" viewBox="0 0 8 34" xmlns="http://www.w3.org/2000/svg">
             <path d="M7.41665 0.583239C7.02784 0.194535 6.55584 0 6.00022 0H2.00007C1.4443 0 0.972306 0.194316 0.583354 0.583239C0.194402 0.972162 0 1.44449 0 1.99985V6.00007C0 6.5558 0.194402 7.02776 0.583354 7.41669C0.972087 7.80539 1.4443 8 2.00007 8H6.00022C6.55584 8 7.02784 7.80561 7.41665 7.41669C7.80545 7.02798 8 6.5558 8 6.00007V1.99978C8.00022 1.44442 7.80596 0.972089 7.41665 0.583239Z"/>
             <path d="M7.41665 26.5832C7.02784 26.1945 6.55584 26 6.00022 26H2.00007C1.4443 26 0.972306 26.1943 0.583354 26.5832C0.194402 26.9722 0 27.4445 0 27.9999V32.0001C0 32.5558 0.194402 33.0278 0.583354 33.4167C0.972087 33.8054 1.4443 34 2.00007 34H6.00022C6.55584 34 7.02784 33.8056 7.41665 33.4167C7.80545 33.028 8 32.5558 8 32.0001V27.9998C8.00022 27.4444 7.80596 26.9721 7.41665 26.5832Z"/>

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -43,7 +43,7 @@
         </div>
     </ng-container>
 </div>
-<div class="footer">
+<div class="footer" [class.readonlyCipher]="isReadOnly">
     <button appBlurClick (click)="addCipher()" (contextmenu)="addCipherOptions()" *ngIf="!isReadOnly"
         class="block primary" appA11yTitle="{{'addItem' | i18n}}" [disabled]="deleted">
         <i class="fa fa-plus fa-lg" aria-hidden="true"></i>

--- a/src/app/vault/ciphers.component.ts
+++ b/src/app/vault/ciphers.component.ts
@@ -19,6 +19,8 @@ export class CiphersComponent extends BaseCiphersComponent {
     isMenuOpened: boolean = false;
     @ViewChild('menu') menu: ElementRef;
 
+    isReadOnly = false;
+
     constructor(searchService: SearchService, protected platformUtilsService: PlatformUtilsService,
         protected i18nService: I18nService, protected cipherService: CipherService,
     ) {

--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -38,6 +38,8 @@
             </div>
         </div>
     </div>
+
+    <app-confirm-trusted-users></app-confirm-trusted-users>
 </div>
 <ng-template #passwordGenerator></ng-template>
 <ng-template #attachments></ng-template>

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -38,6 +38,7 @@ import { EventType } from 'jslib/enums/eventType';
 import { CipherView } from 'jslib/models/view/cipherView';
 import { FolderView } from 'jslib/models/view/folderView';
 
+import { CollectionService } from 'jslib/abstractions/collection.service';
 import { EventService } from 'jslib/abstractions/event.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
@@ -93,7 +94,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         private toasterService: ToasterService, private messagingService: MessagingService,
         private platformUtilsService: PlatformUtilsService, private eventService: EventService,
         private totpService: TotpService, private userService: UserService, private passwordRepromptService: PasswordRepromptService,
-        private sanitizer: DomSanitizer) { }
+        private sanitizer: DomSanitizer, private collectionService: CollectionService) { }
 
     async ngOnInit() {
         this.isAddonInstalled = await this.checkExtensionInit();
@@ -591,6 +592,9 @@ export class VaultComponent implements OnInit, OnDestroy {
         await this.ciphersComponent.reload(c => c.collectionIds != null &&
             c.collectionIds.indexOf(collectionId) > -1);
         this.clearFilters();
+
+        const collection = await this.collectionService.get(collectionId);
+        this.ciphersComponent.isReadOnly = collection.readOnly;
         this.collectionId = collectionId;
         this.updateCollectionProperties();
         this.go();
@@ -697,6 +701,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             // @ts-ignore
             this[prop] = false;
         });
+        this.ciphersComponent.isReadOnly = false;
     }
 
     private go(queryParams: any = null) {

--- a/src/app/vault/view.component.html
+++ b/src/app/vault/view.component.html
@@ -258,7 +258,7 @@
                 </a>
             </div>
         </div>
-        <div class="footer" *ngIf="cipher">
+        <div class="footer" *ngIf="cipher && !isReadOnly">
             <button appBlurClick class="primary" (click)="edit()" appA11yTitle="{{'edit' | i18n}}" *ngIf="!cipher.isDeleted">
                 <i class="fa fa-pencil fa-fw fa-lg" aria-hidden="true"></i>
                 <span>{{'edit' | i18n}}</span>

--- a/src/cozy/services/sharing.service.ts
+++ b/src/cozy/services/sharing.service.ts
@@ -169,7 +169,9 @@ export class SharingService {
     protected async getSharedOrganizations() {
         const organizations = await this.userService.getAllOrganizations();
 
-        const organizationsWithoutCozy = organizations.filter(organization => organization.name !== 'Cozy');
+        const ownedOrganization = organizations.filter(organization => organization.isOwner);
+
+        const organizationsWithoutCozy = ownedOrganization.filter(organization => organization.name !== 'Cozy');
 
         return organizationsWithoutCozy;
     }

--- a/src/cozy/services/sharing.service.ts
+++ b/src/cozy/services/sharing.service.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@angular/core';
+
+import { ApiService } from 'jslib/abstractions/api.service';
+import { CryptoService } from 'jslib/abstractions/crypto.service';
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { UserService } from 'jslib/abstractions/user.service';
+
+import { OrganizationUserStatusType } from 'jslib/enums/organizationUserStatusType';
+import { OrganizationUserType } from 'jslib/enums/organizationUserType';
+
+import { OrganizationUserConfirmRequest } from 'jslib/models/request/organizationUserConfirmRequest';
+
+import { Utils } from 'jslib/misc/utils';
+
+import { CozyClientService } from '../services/cozy-client.service';
+
+
+interface User {
+    name: string;
+    id: string;
+    email: string;
+    publicKey: string;
+    fingerprint: string[];
+    fingerprintPhrase: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SharingService {
+    constructor(
+        protected apiService: ApiService,
+        protected clientService: CozyClientService,
+        protected cryptoService: CryptoService,
+        protected i18nService: I18nService,
+        protected platformUtilsService: PlatformUtilsService,
+        protected userService: UserService
+    ) {}
+
+    async loadOrganizationUsersToBeConfirmed(organizationId: string) {
+        const organizationUsers = await this.apiService.getOrganizationUsers(organizationId);
+
+        const currentUserId = await this.userService.getUserId();
+
+        const isOwner = organizationUsers.data.find(user => {
+            return user.type === OrganizationUserType.Owner
+                && user.id === currentUserId;
+        });
+
+        if (!isOwner) {
+            return [];
+        }
+
+        const invitedUsers = organizationUsers.data.filter(user => {
+            return user.type === OrganizationUserType.User
+                && user.status === OrganizationUserStatusType.Accepted
+                && user.id !== currentUserId;
+        });
+
+        const finalUsers: User[] = [];
+        for (const user of invitedUsers) {
+            const publicKey = (await this.apiService.getUserPublicKey(user.id)).publicKey;
+
+            const fingerprint = await this.cryptoService.getFingerprint(user.id, Utils.fromB64ToArray(publicKey).buffer);
+
+            finalUsers.push({
+                name: user.name,
+                id: user.id,
+                email: user.email,
+                publicKey: publicKey,
+                fingerprint: fingerprint,
+                fingerprintPhrase: fingerprint.join('-'),
+            });
+        }
+
+        return finalUsers;
+    }
+
+    async confirmUser(user: User) {
+        const organizations = await this.userService.getAllOrganizations();
+
+        const organizationsWithoutCozy = organizations.filter(organization => organization.name !== 'Cozy');
+
+        for (const organization of organizationsWithoutCozy) {
+            const organizationUsers = await this.apiService.getOrganizationUsers(organization.id);
+
+            const userInOrganization = organizationUsers.data
+                .filter(organizationUser => organizationUser.status === OrganizationUserStatusType.Accepted)
+                .map(organizationUser => organizationUser.id)
+                .includes(user.id);
+
+            if (userInOrganization) {
+                const orgKey = await this.cryptoService.getOrgKey(organization.id);
+                const key = await this.cryptoService.rsaEncrypt(orgKey.key, Utils.fromB64ToArray(user.publicKey).buffer);
+                const request = new OrganizationUserConfirmRequest();
+                request.key = key.encryptedString;
+
+                await this.apiService.postOrganizationUserConfirm(organization.id, user.id, request);
+            }
+        }
+    }
+
+    async rejectUser(user: User) {
+        try {
+            const client = this.clientService.GetClient();
+
+            await client.stackClient.fetchJSON(
+                'DELETE',
+                `/bitwarden/contacts/${user.id}`,
+                []
+            );
+        } catch {
+            this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
+                this.i18nService.t('unexpectedError'));
+        }
+    }
+}

--- a/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
+++ b/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
@@ -1,0 +1,167 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { AngularWrapperComponent, AngularWrapperProps } from '../angular-wrapper.component';
+
+import { ApiService } from 'jslib/abstractions/api.service';
+import { AuthService } from 'jslib/abstractions/auth.service';
+import { CipherService } from 'jslib/abstractions/cipher.service';
+import { CollectionService } from 'jslib/abstractions/collection.service';
+import { CryptoService } from 'jslib/abstractions/crypto.service';
+import { EnvironmentService } from 'jslib/abstractions/environment.service';
+import { FolderService } from 'jslib/abstractions/folder.service';
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { SyncService } from 'jslib/abstractions/sync.service';
+import { UserService } from 'jslib/abstractions/user.service';
+import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
+
+import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
+
+import { CozyClientService } from '../../services/cozy-client.service';
+import { SharingService, User } from '../../services/sharing.service';
+
+// @ts-ignore
+import ConfirmTrustedUsers from './confirm-trusted-users.jsx';
+
+const BroadcasterSubscriptionId = 'ConfirmTrustedUsersComponent';
+
+interface ConfirmationMethods {
+    getRecipientsToBeConfirmed: (organizationId: string) => User[];
+    confirmRecipient: (organizationId: string) => Promise<void>;
+    rejectRecipient: (organizationId: string) => Promise<void>;
+}
+
+interface ConfirmTrustedUsersProps extends AngularWrapperProps {
+    confirmationMethods: ConfirmationMethods;
+    showModal: boolean;
+    closeModal: () => {};
+}
+
+@Component({
+    selector: 'app-confirm-trusted-users',
+    templateUrl: '../angular-wrapper.component.html',
+    encapsulation: ViewEncapsulation.None,
+})
+export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
+    showModal = false;
+
+    private waitForFirstSync = true;
+
+    constructor(
+        clientService: CozyClientService,
+        apiService: ApiService,
+        environmentService: EnvironmentService,
+        authService: AuthService,
+        syncService: SyncService,
+        cryptoService: CryptoService,
+        cipherService: CipherService,
+        userService: UserService,
+        collectionService: CollectionService,
+        passwordGenerationService: PasswordGenerationService,
+        vaultTimeoutService: VaultTimeoutService,
+        folderService: FolderService,
+        i18nService: I18nService,
+        platformUtilsService: PlatformUtilsService,
+        protected sharingService: SharingService,
+        protected broadcasterService: BroadcasterService
+    ) {
+        super(
+            clientService,
+            apiService,
+            environmentService,
+            authService,
+            syncService,
+            cryptoService,
+            cipherService,
+            userService,
+            collectionService,
+            passwordGenerationService,
+            vaultTimeoutService,
+            folderService,
+            i18nService,
+            platformUtilsService
+        );
+    }
+
+    ngOnInit() {
+        super.ngOnInit();
+
+        this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
+            switch (message.command) {
+                case 'syncCompleted':
+                    if (this.waitForFirstSync) {
+                        this.waitForFirstSync = false;
+
+                        this.showModal = true;
+                        this.renderReact();
+                    }
+                    break;
+            }
+        });
+    }
+
+    /******************/
+    /* Props Bindings */
+    /******************/
+
+    protected async getProps(): Promise<ConfirmTrustedUsersProps> {
+        const reactWrapperProps = await this.getReactWrapperProps();
+
+        return {
+            reactWrapperProps: reactWrapperProps,
+            confirmationMethods: this.getTwoStepsConfirmationMethods(),
+            showModal: this.showModal,
+            closeModal: this.closeModal.bind(this),
+        };
+    }
+
+    /**********/
+    /* Render */
+    /**********/
+
+    protected async renderReact() {
+        ReactDOM.render(
+            React.createElement(ConfirmTrustedUsers, await this.getProps()),
+            this.getRootDomNode()
+        );
+    }
+
+    /************************/
+    /* Confirmation Methods */
+    /************************/
+
+    protected async loadUsersToBeConfirmed() {
+        return await this.sharingService.loadAllUsersToBeConfirmed();
+    }
+
+    protected async confirmUser(user: User) {
+        return await this.sharingService.confirmUser(user);
+    }
+
+    protected async rejectUser(user: User) {
+        return await this.sharingService.rejectUser(user);
+    }
+
+    protected getTwoStepsConfirmationMethods(): ConfirmationMethods {
+        const loadUsersToBeConfirmed = this.loadUsersToBeConfirmed.bind(this);
+        const confirmUser = this.confirmUser.bind(this);
+        const rejectUser = this.rejectUser.bind(this);
+
+        return {
+            getRecipientsToBeConfirmed: loadUsersToBeConfirmed,
+            confirmRecipient: confirmUser,
+            rejectRecipient: rejectUser,
+        };
+    }
+
+    /***************/
+    /* Modal state */
+    /***************/
+
+    protected closeModal() {
+        this.showModal = false;
+        this.renderReact();
+    }
+}

--- a/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
+++ b/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
@@ -48,6 +48,7 @@ export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
     showModal = false;
 
     private waitForFirstSync = true;
+    private usersToBeConfirmedCached: User[] = null;
 
     constructor(
         clientService: CozyClientService,
@@ -122,6 +123,12 @@ export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
     /**********/
 
     protected async renderReact() {
+        this.usersToBeConfirmedCached = await this.sharingService.loadAllUsersToBeConfirmed();
+
+        if (this.usersToBeConfirmedCached.length === 0) {
+            return;
+        }
+
         ReactDOM.render(
             React.createElement(ConfirmTrustedUsers, await this.getProps()),
             this.getRootDomNode()
@@ -133,6 +140,13 @@ export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
     /************************/
 
     protected async loadUsersToBeConfirmed() {
+        if (this.usersToBeConfirmedCached) {
+            const result = this.usersToBeConfirmedCached;
+            this.usersToBeConfirmedCached = null;
+
+            return result;
+        }
+
         return await this.sharingService.loadAllUsersToBeConfirmed();
     }
 

--- a/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.jsx
+++ b/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import SharingProvider, { ConfirmTrustedRecipientsDialog, CozyPassFingerprintDialogContent } from 'cozy-sharing'
+
+import ReactWrapper, { reactWrapperProps } from '../react-wrapper';
+
+const ConfirmTrustedUsers = ({
+    reactWrapperProps,
+    confirmationMethods,
+    showModal = false,
+    closeModal
+}) => {
+  const twoStepsConfirmationMethods = {
+    ...confirmationMethods,
+    recipientConfirmationDialogContent: CozyPassFingerprintDialogContent,
+  }
+
+  return (
+    <ReactWrapper reactWrapperProps={reactWrapperProps}>
+      <SharingProvider doctype="com.bitwarden.organizations" documentType="Organizations" previewPath="">
+        {showModal && (
+          <ConfirmTrustedRecipientsDialog
+            onClose={closeModal}
+            twoStepsConfirmationMethods={twoStepsConfirmationMethods}
+          />
+        )}
+      </SharingProvider>
+    </ReactWrapper>
+  )
+}
+
+ConfirmTrustedUsers.propTypes = {
+  reactWrapperProps: reactWrapperProps.isRequired,
+  showModal: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired
+}
+
+export default ConfirmTrustedUsers

--- a/src/cozy/wrappers/sharing/sharing.component.ts
+++ b/src/cozy/wrappers/sharing/sharing.component.ts
@@ -42,9 +42,18 @@ interface ConfirmationMethods {
     rejectRecipient: (organizationId: string) => Promise<void>;
 }
 
+interface OnSharedEventArgs {
+    document: File;
+    recipients: any[];
+    readOnlyRecipients: any[];
+}
+
+type OnSharedEvent = (args: OnSharedEventArgs) => Promise<void>;
+
 interface SharingProps extends AngularWrapperProps {
     file: File;
     confirmationMethods: ConfirmationMethods;
+    onShared: OnSharedEvent;
 }
 
 interface User {
@@ -119,6 +128,7 @@ export class SharingComponent extends AngularWrapperComponent {
                 _id: currentCollection.organizationId,
             },
             confirmationMethods: this.getTwoStepsConfirmationMethods(),
+            onShared: this.onShared.bind(this),
         };
     }
 
@@ -159,5 +169,20 @@ export class SharingComponent extends AngularWrapperComponent {
             confirmRecipient: confirmUser,
             rejectRecipient: rejectUser,
         };
+    }
+
+    /*********************/
+    /* Sharing Listeners */
+    /*********************/
+
+    protected async onShared({
+        document,
+        recipients,
+        readOnlyRecipients,
+    }: OnSharedEventArgs) {
+        const recipientsToConfirm = [...recipients, ...readOnlyRecipients];
+        const organizationId = document.id;
+
+        await this.sharingService.autoConfirmTrustedUsers(organizationId, recipientsToConfirm);
     }
 }

--- a/src/cozy/wrappers/sharing/sharing.component.ts
+++ b/src/cozy/wrappers/sharing/sharing.component.ts
@@ -72,6 +72,7 @@ interface User {
 })
 export class SharingComponent extends AngularWrapperComponent {
     @Input() collectionId: string = null;
+    private organizationId: string = null;
 
     constructor(
         clientService: CozyClientService,
@@ -117,6 +118,8 @@ export class SharingComponent extends AngularWrapperComponent {
 
         const currentCollection = collections.find(collection => collection.id === this.collectionId);
 
+        this.organizationId = currentCollection.organizationId;
+
         const reactWrapperProps = await this.getReactWrapperProps();
 
         return {
@@ -147,8 +150,8 @@ export class SharingComponent extends AngularWrapperComponent {
     /* Confirmation Methods */
     /************************/
 
-    protected async loadOrganizationUsersToBeConfirmed(organizationId: string) {
-        return await this.sharingService.loadOrganizationUsersToBeConfirmed(organizationId);
+    protected async loadOrganizationUsersToBeConfirmed() {
+        return await this.sharingService.loadOrganizationUsersToBeConfirmed(this.organizationId);
     }
 
     protected async confirmUser(user: User) {

--- a/src/cozy/wrappers/sharing/sharing.component.ts
+++ b/src/cozy/wrappers/sharing/sharing.component.ts
@@ -37,9 +37,9 @@ interface File {
 }
 
 interface ConfirmationMethods {
-    getRecipientsToBeConfirmed: (organizationId: string) => User[];
-    confirmRecipient: (organizationId: string) => Promise<void>;
-    rejectRecipient: (organizationId: string) => Promise<void>;
+    getRecipientsToBeConfirmed: () => User[];
+    confirmRecipient: (user: User) => Promise<void>;
+    rejectRecipient: (user: User) => Promise<void>;
 }
 
 interface OnSharedEventArgs {

--- a/src/cozy/wrappers/sharing/sharing.jsx
+++ b/src/cozy/wrappers/sharing/sharing.jsx
@@ -8,7 +8,8 @@ import ReactWrapper, { reactWrapperProps } from '../react-wrapper';
 const Sharing = ({ 
     file,
     reactWrapperProps,
-    confirmationMethods
+    confirmationMethods,
+    onShared
 }) => {
   const [showShareModal, setShowShareModal] = useState(false)
 
@@ -19,7 +20,7 @@ const Sharing = ({
 
   return (
     <ReactWrapper reactWrapperProps={reactWrapperProps}>
-      <SharingProvider doctype="com.bitwarden.organizations" documentType="Organizations" previewPath="">
+      <SharingProvider doctype="com.bitwarden.organizations" documentType="Organizations" previewPath="" onShared={onShared}>
         {showShareModal && (
           <ShareModal
           document={file}

--- a/src/scss/cozy.scss
+++ b/src/scss/cozy.scss
@@ -89,6 +89,14 @@ app-vault-ciphers {
             fill: var(--secondaryTextColor);
         }
     }
+
+    app-sharing {
+        margin: 0 10px;
+    }
+    
+    .footer.readonlyCipher {
+        justify-content: center;
+    }
 }
 
 .navbar-entry {

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,0 +1,138 @@
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { TokenService } from 'jslib/abstractions/token.service';
+import { DeviceType } from 'jslib/enums/deviceType';
+import { Utils } from 'jslib/misc/utils';
+import { EnvironmentUrls } from 'jslib/models/domain/environmentUrls';
+import { CollectionDetailsResponse } from 'jslib/models/response/collectionResponse';
+import { ErrorResponse } from 'jslib/models/response/errorResponse';
+import { ListResponse } from 'jslib/models/response/listResponse';
+import { ApiService as ApiServiceBase } from 'jslib/services/api.service';
+
+export class ApiService extends ApiServiceBase {
+    private localDevice: DeviceType;
+    private localDeviceType: string;
+    private localIsWebClient = false;
+    private localUsingBaseUrl = false;
+
+    constructor(
+        tokenService: TokenService,
+        platformUtilsService: PlatformUtilsService,
+        private localLogoutCallback: (expired: boolean) => Promise<void>,
+        private localCustomUserAgent: string = null
+    ) {
+        super(
+            tokenService,
+            platformUtilsService,
+            localLogoutCallback,
+            localCustomUserAgent);
+
+        this.localDevice = platformUtilsService.getDevice();
+        this.localDeviceType = this.localDevice.toString();
+
+        this.localIsWebClient = this.localDevice === DeviceType.IEBrowser || this.localDevice === DeviceType.ChromeBrowser ||
+            this.localDevice === DeviceType.EdgeBrowser || this.localDevice === DeviceType.FirefoxBrowser ||
+            this.localDevice === DeviceType.OperaBrowser || this.localDevice === DeviceType.SafariBrowser ||
+            this.localDevice === DeviceType.UnknownBrowser || this.localDevice === DeviceType.VivaldiBrowser;
+    }
+
+    setUrls(urls: EnvironmentUrls): void {
+        super.setUrls(urls);
+
+        if (urls.base != null) {
+            this.localUsingBaseUrl = true;
+        }
+    }
+
+    async getCollections(organizationId: string): Promise<ListResponse<CollectionDetailsResponse>> {
+        const r = await this.localSend('GET', '/organizations/' + organizationId + '/collections', null, true, true);
+        return new ListResponse(r, CollectionDetailsResponse);
+    }
+
+    private async localSend(
+        method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+        path: string,
+        body: any,
+        authed: boolean,
+        hasResponse: boolean,
+        apiUrl?: string
+    ): Promise<any> {
+        apiUrl = Utils.isNullOrWhitespace(apiUrl) ? this.apiBaseUrl : apiUrl;
+        const headers = new Headers({
+            'Device-Type': this.localDeviceType,
+        });
+        if (this.localCustomUserAgent != null) {
+            headers.set('User-Agent', this.localCustomUserAgent);
+        }
+
+        const requestInit: RequestInit = {
+            cache: 'no-store',
+            credentials: this.localGetCredentials(),
+            method: method,
+        };
+
+        if (authed) {
+            const authHeader = await this.getActiveBearerToken();
+            headers.set('Authorization', 'Bearer ' + authHeader);
+        }
+        if (body != null) {
+            if (typeof body === 'string') {
+                requestInit.body = body;
+                headers.set('Content-Type', 'application/x-www-form-urlencoded; charset=utf-8');
+            } else if (typeof body === 'object') {
+                if (body instanceof FormData) {
+                    requestInit.body = body;
+                } else {
+                    headers.set('Content-Type', 'application/json; charset=utf-8');
+                    requestInit.body = JSON.stringify(body);
+                }
+            }
+        }
+        if (hasResponse) {
+            headers.set('Accept', 'application/json');
+        }
+
+        requestInit.headers = headers;
+        const response = await this.fetch(new Request(apiUrl + path, requestInit));
+
+        if (hasResponse && response.status === 200) {
+            const responseJson = await response.json();
+            return responseJson;
+        } else if (response.status !== 200) {
+            const error = await this.localHandleError(response, false, authed);
+            return Promise.reject(error);
+        }
+    }
+
+    private localGetCredentials(): RequestCredentials {
+        if (!this.localIsWebClient || this.localUsingBaseUrl) {
+            return 'include';
+        }
+        return undefined;
+    }
+
+    private async localHandleError(response: Response, tokenError: boolean, authed: boolean): Promise<ErrorResponse> {
+        if (authed && ((tokenError && response.status === 400) || response.status === 401 || response.status === 403)) {
+            await this.localLogoutCallback(true);
+            return null;
+        }
+
+        let responseJson: any = null;
+        if (this.localIsJsonResponse(response)) {
+            responseJson = await response.json();
+        } else if (this.localIsTextResponse(response)) {
+            responseJson = { Message: await response.text() };
+        }
+
+        return new ErrorResponse(responseJson, response.status, tokenError);
+    }
+
+    private localIsJsonResponse(response: Response): boolean {
+        const typeHeader = response.headers.get('content-type');
+        return typeHeader != null && typeHeader.indexOf('application/json') > -1;
+    }
+
+    private localIsTextResponse(response: Response): boolean {
+        const typeHeader = response.headers.get('content-type');
+        return typeHeader != null && typeHeader.indexOf('text') > -1;
+    }
+}

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -8,6 +8,7 @@ import { SendService } from 'jslib/abstractions/send.service';
 import { SettingsService } from 'jslib/abstractions/settings.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
 import { TokenService } from 'jslib/abstractions/token.service';
+import { CollectionDetailsResponse } from 'jslib/models/response/collectionResponse';
 import { SyncCipherNotification } from 'jslib/models/response/notificationResponse';
 import { ProfileOrganizationResponse } from 'jslib/models/response/profileOrganizationResponse';
 import { SyncService as SyncServiceBase } from 'jslib/services/sync.service';
@@ -187,13 +188,13 @@ export class SyncService extends SyncServiceBase {
     protected async syncUpsertCollections(organizationId: string, isEdit: boolean) {
         const syncCollections = await this.localApiService.getCollections(organizationId);
 
-        await this.localCollectionService.upsert(syncCollections.data.map(col => {
+        await this.localCollectionService.upsert(syncCollections.data.map((col: CollectionDetailsResponse) => {
             return {
                 externalId: col.externalId,
                 id: col.id,
                 name: col.name,
                 organizationId: col.organizationId,
-                readOnly: false, // TODO: this should be set later
+                readOnly: col.readOnly,
             };
         }));
     }


### PR DESCRIPTION
When a folder (organization) is shared with Bob with Readonly settings, then Bob shouldn't be able to add/modify/delete ciphers inside of this folder.

This PR hide `add`, `edit`, `delete` related buttons when in a readonly context.

## Ciphers list
### in a writable collection
![image](https://user-images.githubusercontent.com/1884255/133797172-a3f1fe58-30c2-484d-b343-c514c10a5f11.png)

### Ciphers view in a readonly collection
![image](https://user-images.githubusercontent.com/1884255/133797208-3d8497bc-90b0-4ae1-96e2-555e16541064.png)


## Ciphers view
### with a writable cipher selected
![image](https://user-images.githubusercontent.com/1884255/133798131-cca3c601-7ba4-46d9-a751-f7d7cad05a45.png)

### with a readonly cipher selected
![image](https://user-images.githubusercontent.com/1884255/133798103-0c973235-aa23-426d-8af2-dffd36b0c0e5.png)

