### PR TITLE
fix: use correct Sprit import

### DIFF
--- a/src/cozy/wrappers/icon-sprite/icon-sprite.component.ts
+++ b/src/cozy/wrappers/icon-sprite/icon-sprite.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 // @ts-ignore
-import { Sprite as IconSprite } from 'cozy-ui/transpiled/react/Icon';
+import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { AngularWrapperComponent } from '../angular-wrapper.component';
@@ -16,6 +16,6 @@ export class IconSpriteComponent extends AngularWrapperComponent {
     /**********/
 
     protected renderReact() {
-        ReactDOM.render(React.createElement(IconSprite), this.getRootDomNode());
+        ReactDOM.render(React.createElement(Sprite), this.getRootDomNode());
     }
 }


### PR DESCRIPTION
Change the way Sprit are imported to reflect latest changes from
cozy/cozy-ui@478e9d258804b88f13fb6bae3b0cc6626b8f53e6

___

⚠️ this PR cannot be merged yet, cozy-ui need to be upgraded to 52.0.1 first (will be done with https://github.com/cozy/cozy-pass-web/pull/51)