### PR TITLE
feat: display org with no key in navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Show users confirmation dialog after opening vault ([PR #51](https://github.com/cozy/cozy-pass-web/pull/51))
 * Automatically confirm a trusted user after initializing a sharing ([PR #51](https://github.com/cozy/cozy-pass-web/pull/51))
 * Add support for ReadOnly shared ciphers and folders ([PR #53](https://github.com/cozy/cozy-pass-web/pull/53))
+* Display shared folders that need to be confirmed before being accessible in the navbar ([PR #54](https://github.com/cozy/cozy-pass-web/pull/54))
 
 ## 🐛 Bug Fixes
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -63,6 +63,7 @@ import { ViewComponent } from './vault/view.component';
 
 import { ButtonExtensionComponent } from '../cozy/wrappers/button-extension/button-extension.component';
 import { ConfirmTrustedUsersComponent } from '../cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component';
+import { ConfirmYourIdentityComponent } from '../cozy/wrappers/confirm-your-identity-dialog/confirm-your-identity-dialog.component';
 import { CozyIconComponent } from '../cozy/wrappers/cozy-icon/cozy-icon.component';
 import { IconSpriteComponent } from '../cozy/wrappers/icon-sprite/icon-sprite.component';
 import { ImportPageComponent } from '../cozy/wrappers/import-page/import-page.component';
@@ -231,6 +232,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         IfFlagDirective,
         SharingComponent,
         ConfirmTrustedUsersComponent,
+        ConfirmYourIdentityComponent,
     ],
     entryComponents: [
         AttachmentsComponent,

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -108,7 +108,7 @@ const tokenService = new TokenService(storageService);
 const appIdService = new AppIdService(storageService);
 const apiService = new ApiService(tokenService, platformUtilsService,
     async (expired: boolean) => messagingService.send('logout', { expired: expired }));
-const userService = new UserService(tokenService, storageService, cryptoService);
+const userService = new UserService(tokenService, storageService, cryptoService, apiService);
 const sharingService = new SharingService(apiService, clientService, cryptoService, i18nService, platformUtilsService, userService);
 const settingsService = new SettingsService(userService, storageService);
 export let searchService: SearchService = null;
@@ -220,6 +220,7 @@ export function initFactory(): Function {
         { provide: SyncServiceAbstraction, useValue: syncService },
         { provide: SyncService, useValue: syncService },
         { provide: UserServiceAbstraction, useValue: userService },
+        { provide: UserService, useValue: userService },
         { provide: MessagingServiceAbstraction, useValue: messagingService },
         { provide: BroadcasterService, useValue: broadcasterService },
         { provide: SettingsServiceAbstraction, useValue: settingsService },

--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -95,7 +95,7 @@
             </div>
             <ul>
                 <ng-template #recursiveCollections let-collections>
-                    <li *ngFor="let c of collections" [ngClass]="{active: c.node.id === selectedCollectionId}" class="navbar-entry">
+                    <li *ngFor="let c of collections" [ngClass]="{active: c.node.id === selectedCollectionId, orgNoKey: isOrgWithNoKey(c.node)}" class="navbar-entry">
                         <a href="#" appStopClick appBlurClick (click)="selectCollection(c.node)">
                             <i *ngIf="c.children.length" class="fa-fw fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
                                 [ngClass]="{'fa-caret-right': isCollapsed(c.node), 'fa-caret-down': !isCollapsed(c.node)}"
@@ -158,6 +158,7 @@
             </li>
         </ul>
     </div>
+    <app-confirm-your-identity-dialog></app-confirm-your-identity-dialog>
     <app-button-extension></app-button-extension>
     <!-- <div class="footer">
         <app-nav class="nav"></app-nav>

--- a/src/cozy/react/locales/en.json
+++ b/src/cozy/react/locales/en.json
@@ -159,5 +159,12 @@
         "safari": "Install on Safari"
       }
     }
+  },
+
+  "ConfirmYourIdentityModal": {
+    "title": "Verify your identity",
+    "instruction": "You cannot access this folder's ciphers yet. To finalize the sharing and access your shared ciphers, contact %{ownerName} via the means of communication of your choice (call, text message, instant messaging app...) and give them your security code:",
+    "instruction2": "Your security code will allow %{ownerName} to confirm your identity and then you will be able to access your shared ciphers.",
+    "confirm": "OK"
   }
 }

--- a/src/cozy/react/locales/fr.json
+++ b/src/cozy/react/locales/fr.json
@@ -158,5 +158,12 @@
         "safari": "Installer sur Safari"
       }
     }
+  },
+
+  "ConfirmYourIdentityModal": {
+    "title": "Vérification de votre identité",
+    "instruction": "Les mots de passe de ce dossier ne vous sont pas encore accessibles. Pour finaliser le partage et accéder aux mots de passe partagés, veuillez transmettre par le moyen de votre choix (Appel, SMS, messagerie instantanée, ...) votre code de sécurité à %{ownerName} :",
+    "instruction2": "Ce code de sécurité permettra à %{ownerName} de valider votre identité et ainsi d'accéder aux éléments partagés.",
+    "confirm": "J'ai compris"
   }
 }

--- a/src/cozy/wrappers/confirm-your-identity-dialog/confirm-your-identity-dialog.component.ts
+++ b/src/cozy/wrappers/confirm-your-identity-dialog/confirm-your-identity-dialog.component.ts
@@ -1,0 +1,140 @@
+import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { OrganizationUserStatusType } from 'jslib/enums/organizationUserStatusType';
+import { OrganizationUserType } from 'jslib/enums/organizationUserType';
+import { Utils } from 'jslib/misc/utils';
+import { OrganizationUserConfirmRequest } from 'jslib/models/request/organizationUserConfirmRequest';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { AngularWrapperComponent, AngularWrapperProps } from '../angular-wrapper.component';
+
+import { ApiService } from 'jslib/abstractions/api.service';
+import { AuthService } from 'jslib/abstractions/auth.service';
+import { CipherService } from 'jslib/abstractions/cipher.service';
+import { CollectionService } from 'jslib/abstractions/collection.service';
+import { CryptoService } from 'jslib/abstractions/crypto.service';
+import { EnvironmentService } from 'jslib/abstractions/environment.service';
+import { FolderService } from 'jslib/abstractions/folder.service';
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { SyncService } from 'jslib/abstractions/sync.service';
+import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
+
+import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
+
+import { UserService } from '../../../services/user.service';
+import { CozyClientService } from '../../services/cozy-client.service';
+
+// @ts-ignore
+import ConfirmYourIdentity from './confirm-your-identity-dialog.jsx';
+
+const BroadcasterSubscriptionId = 'ConfirmYourIdentityComponent';
+
+interface ConfirmYourIdentityProps extends AngularWrapperProps {
+    ownerName: string;
+    fingerprintPhrase: string;
+    showModal: boolean;
+    closeModal: () => {};
+}
+
+@Component({
+    selector: 'app-confirm-your-identity-dialog',
+    templateUrl: '../angular-wrapper.component.html',
+    encapsulation: ViewEncapsulation.None,
+})
+export class ConfirmYourIdentityComponent extends AngularWrapperComponent {
+    showModal = false;
+    private organizationId: string = null;
+
+    constructor(
+        clientService: CozyClientService,
+        apiService: ApiService,
+        environmentService: EnvironmentService,
+        authService: AuthService,
+        syncService: SyncService,
+        cryptoService: CryptoService,
+        cipherService: CipherService,
+        protected localUserService: UserService,
+        collectionService: CollectionService,
+        passwordGenerationService: PasswordGenerationService,
+        vaultTimeoutService: VaultTimeoutService,
+        folderService: FolderService,
+        i18nService: I18nService,
+        platformUtilsService: PlatformUtilsService,
+        protected broadcasterService: BroadcasterService
+    ) {
+        super(
+            clientService,
+            apiService,
+            environmentService,
+            authService,
+            syncService,
+            cryptoService,
+            cipherService,
+            localUserService,
+            collectionService,
+            passwordGenerationService,
+            vaultTimeoutService,
+            folderService,
+            i18nService,
+            platformUtilsService
+        );
+    }
+
+    ngOnInit() {
+        super.ngOnInit();
+
+        this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
+            switch (message.command) {
+                case 'showConfirmYourIdentityDialog':
+                    this.organizationId = message.organizationId;
+                    this.showModal = true;
+                    this.renderReact();
+                    break;
+            }
+        });
+    }
+
+    /******************/
+    /* Props Bindings */
+    /******************/
+
+    protected async getProps(): Promise<ConfirmYourIdentityProps> {
+        const reactWrapperProps = await this.getReactWrapperProps();
+
+        const userId = await this.userService.getUserId();
+        const fingerprint = await this.cryptoService.getFingerprint(userId);
+
+        const owner = await this.localUserService.getOrganizationOwner(this.organizationId);
+
+        return {
+            reactWrapperProps: reactWrapperProps,
+            ownerName: owner.name,
+            fingerprintPhrase: fingerprint.join('-'),
+            showModal: this.showModal,
+            closeModal: this.closeModal.bind(this),
+        };
+    }
+
+    /**********/
+    /* Render */
+    /**********/
+
+    protected async renderReact() {
+        if (this.organizationId) {
+            ReactDOM.render(
+                React.createElement(ConfirmYourIdentity, await this.getProps()),
+                this.getRootDomNode()
+            );
+        }
+    }
+
+    /***************/
+    /* Modal state */
+    /***************/
+
+    protected closeModal() {
+        this.showModal = false;
+        this.renderReact();
+    }
+}

--- a/src/cozy/wrappers/confirm-your-identity-dialog/confirm-your-identity-dialog.jsx
+++ b/src/cozy/wrappers/confirm-your-identity-dialog/confirm-your-identity-dialog.jsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import ReactWrapper, { reactWrapperProps } from '../react-wrapper';
+
+import Button from 'cozy-ui/transpiled/react/Button'
+import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Paper from 'cozy-ui/transpiled/react/Paper'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import './styles.css'
+
+const ConfirmYourIdentityModal = ({ 
+  ownerName,
+  fingerprintPhrase,
+  onClose
+}) => {
+  const { t } = useI18n()
+  
+  let dialogTitle = t(`ConfirmYourIdentityModal.title`)
+
+  const instruction1 =  t(`ConfirmYourIdentityModal.instruction`, {
+    ownerName: ownerName
+  })
+
+  const instruction2 = t(`ConfirmYourIdentityModal.instruction2`, {
+    ownerName: ownerName
+  })
+
+  let dialogContent = (
+    <>
+      <div>
+        <Typography variant="body1">
+          {instruction1}
+        </Typography>
+        <Paper
+          className="ConfirmYourIdentityModal__fingerprint"
+          elevation={1}
+        >
+          <Typography variant="body1">
+            {fingerprintPhrase}
+          </Typography>
+        </Paper>
+        <Typography variant="body1">
+          {instruction2}
+        </Typography>
+      </div>
+    </>
+  )
+  let dialogActions = (
+    <Button
+      theme="primary"
+      label={t(`ConfirmYourIdentityModal.confirm`)}
+      onClick={onClose}
+    />
+  )
+
+  return (
+    <FixedDialog
+      disableEnforceFocus
+      open={true}
+      onClose={onClose}
+      title={dialogTitle}
+      content={dialogContent}
+      actions={dialogActions}
+    />
+  )
+}
+
+const ConfirmYourIdentity = ({
+    reactWrapperProps,
+    ownerName,
+    fingerprintPhrase,
+    showModal = false,
+    closeModal
+}) => {
+  return (
+    <ReactWrapper reactWrapperProps={reactWrapperProps}>
+      {showModal && (
+        <ConfirmYourIdentityModal
+          ownerName={ownerName}
+          fingerprintPhrase={fingerprintPhrase}
+          onClose={closeModal}
+        >
+        </ConfirmYourIdentityModal>
+      )}
+      
+    </ReactWrapper>
+  )
+}
+
+ConfirmYourIdentity.propTypes = {
+  reactWrapperProps: reactWrapperProps.isRequired,
+  ownerName: PropTypes.string.isRequired,
+  fingerprintPhrase: PropTypes.string.isRequired,
+  showModal: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired
+}
+
+export default ConfirmYourIdentity

--- a/src/cozy/wrappers/confirm-your-identity-dialog/styles.css
+++ b/src/cozy/wrappers/confirm-your-identity-dialog/styles.css
@@ -1,0 +1,8 @@
+.ConfirmYourIdentityModal__fingerprint {
+  padding: 16px;
+  margin: 24px 0;
+  text-align: center;
+}
+.ConfirmYourIdentityModal__fingerprint p {
+  color: var(--secondaryColor);
+}

--- a/src/scss/cozy.scss
+++ b/src/scss/cozy.scss
@@ -81,6 +81,10 @@ app-vault-groupings {
             fill: var(--secondaryTextColor);
         }
     }
+
+    .orgNoKey {
+        opacity: 0.2;
+    }
 }
 
 app-vault-ciphers {


### PR DESCRIPTION
~~⚠️ this PR must not be merged on `feat/auto_accept_trusted_users` but on `master`. The target branch will be edited after `feat/auto_accept_trusted_users` merge~~

~~⚠️ this PR should not be merged before `feat/auto_accept_trusted_users`~~
____

In be19101f7c286e9dfc1c1a18babded26ea62a754 we chose to hide
organizations with no encryption key to prevent encryption error
messages

Those organizations are shared organizations that are not confirmed by
the sharing owner

This commit display them again in the navbar but with a greyed style

When clicking on those organizations then we display a dialog to
explain to the user that they need to confirm their identity to
finalize the sharing