### PR TITLE
fix: don't show `share` button on `Cozy Connectors` folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## 🐛 Bug Fixes
 
+* Hide `Sare` button from `Cozy Connectors` folder ([PR #55](https://github.com/cozy/cozy-pass-web/pull/55))
 
 ## 🔧 Tech
 

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -48,7 +48,7 @@
         class="block primary" appA11yTitle="{{'addItem' | i18n}}" [disabled]="deleted">
         <i class="fa fa-plus fa-lg" aria-hidden="true"></i>
     </button>
-    <app-sharing *ngIf="collectionId" [collectionId]="collectionId"></app-sharing>
+    <app-sharing *ngIf="collectionId && !isCozyConnectors" [collectionId]="collectionId"></app-sharing>
     <button id="param-btn" (click)="openMenu()" *ngIf="!isReadOnly">
         <svg width="4" height="17" viewBox="0 0 8 34" xmlns="http://www.w3.org/2000/svg">
             <path d="M7.41665 0.583239C7.02784 0.194535 6.55584 0 6.00022 0H2.00007C1.4443 0 0.972306 0.194316 0.583354 0.583239C0.194402 0.972162 0 1.44449 0 1.99985V6.00007C0 6.5558 0.194402 7.02776 0.583354 7.41669C0.972087 7.80539 1.4443 8 2.00007 8H6.00022C6.55584 8 7.02784 7.80561 7.41665 7.41669C7.80545 7.02798 8 6.5558 8 6.00007V1.99978C8.00022 1.44442 7.80596 0.972089 7.41665 0.583239Z"/>

--- a/src/app/vault/ciphers.component.ts
+++ b/src/app/vault/ciphers.component.ts
@@ -20,6 +20,7 @@ export class CiphersComponent extends BaseCiphersComponent {
     @ViewChild('menu') menu: ElementRef;
 
     isReadOnly = false;
+    isCozyConnectors = false;
 
     constructor(searchService: SearchService, protected platformUtilsService: PlatformUtilsService,
         protected i18nService: I18nService, protected cipherService: CipherService,

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -595,6 +595,10 @@ export class VaultComponent implements OnInit, OnDestroy {
 
         const collection = await this.collectionService.get(collectionId);
         this.ciphersComponent.isReadOnly = collection.readOnly;
+
+        const decryptedCollection = (await this.collectionService.decryptMany([collection]))[0];
+        this.ciphersComponent.isCozyConnectors = decryptedCollection.name === 'Cozy Connectors';
+
         this.collectionId = collectionId;
         this.updateCollectionProperties();
         this.go();
@@ -702,6 +706,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             this[prop] = false;
         });
         this.ciphersComponent.isReadOnly = false;
+        this.ciphersComponent.isCozyConnectors = false;
     }
 
     private go(queryParams: any = null) {


### PR DESCRIPTION
~~⚠️ this PR must not be merged on `feat/readonly` but on `master`. The target branch will be edited after `feat/readonly` merge~~

~~⚠️ this PR should not be merged before `feat/readonly`~~
____

Because `Cozy Connectors` is not a classic organization, user cannot
share it with others

So in this case `share` button is now hidden