### PR TITLE
fix: handle `getAllDecrypted` case where orgs are not synced yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## 🐛 Bug Fixes
 
 * Hide `Sare` button from `Cozy Connectors` folder ([PR #55](https://github.com/cozy/cozy-pass-web/pull/55))
+* Fix loading issue on first sync ([PR #56](https://github.com/cozy/cozy-pass-web/pull/56))
 
 ## 🔧 Tech
 

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -43,7 +43,7 @@ export class CipherService extends CipherServiceBase {
         }
 
         const orgKeys = await this.localCryptoService.getOrgKeys();
-        const orgIds = [...orgKeys.keys()];
+        const orgIds = orgKeys ? [...orgKeys.keys()] : [];
 
         const promises: any[] = [];
         const ciphers = (await this.getAll())


### PR DESCRIPTION
~~⚠️ this PR must not be merged on `feat/readonly` but on `master`. The target branch will be edited after `feat/readonly` merge~~

~~⚠️ this PR should not be merged before `feat/readonly`~~
____

On first `getAllDecrypted()` call, orgs may not have been synced yet

In this case `getAllDecrypted` would throw while getting all org ids

This error was non blocking as it was call on `GroupingsComponent` load
to check if Notes (cipher.type === 2) are in the list. As we don't
handle Notes this had no impact other than displaying an error in the
console

Now this case is handled correctly