### PR TITLE
Fix/close confirmtrustedusersmodal

### DIFF
--- a/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
+++ b/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
@@ -151,7 +151,13 @@ export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
             return result;
         }
 
-        return await this.sharingService.loadAllUsersToBeConfirmed();
+        const usersToBeConfirmed = await this.sharingService.loadAllUsersToBeConfirmed();
+
+        if (usersToBeConfirmed.length === 0 && this.showModal === true) {
+            this.closeModal();
+        }
+
+        return usersToBeConfirmed;
     }
 
     protected async confirmUser(user: User) {

--- a/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
+++ b/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
@@ -96,7 +96,7 @@ export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
                         this.waitForFirstSync = false;
 
                         this.showModal = true;
-                        this.renderReact();
+                        this.firstRenderReact();
                     }
                     break;
             }
@@ -122,13 +122,17 @@ export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
     /* Render */
     /**********/
 
-    protected async renderReact() {
+    protected async firstRenderReact() {
         this.usersToBeConfirmedCached = await this.sharingService.loadAllUsersToBeConfirmed();
 
         if (this.usersToBeConfirmedCached.length === 0) {
             return;
         }
 
+        this.renderReact();
+    }
+
+    protected async renderReact() {
         ReactDOM.render(
             React.createElement(ConfirmTrustedUsers, await this.getProps()),
             this.getRootDomNode()


### PR DESCRIPTION
This PR fix a bug that prevented to close the `ConfirmTrustedUsersComponent` modal after confirming the last user

Also this add a feature that auto-close the modal after confirming the last user