### PR TITLE
refactor: remove hack when moving ciphers between and out of folders

### DIFF
--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -60,33 +60,9 @@ export class CipherService extends CipherServiceBase {
         return this.decryptedCipherCache;
     }
 
-    /**
-     * Hack of shareWithServer that deletes/recreates the cipher instead of updating the existing one
-     * This hack allows to temporary fix a realtime sync problem from stack when we try
-     * to remove a cipher from an organization
-     */
-    async shareWithServer(cipher: CipherView, organizationId: string, collectionIds: string[]): Promise<any> {
-        await this.deleteWithServer(cipher.id);
-
-        cipher.id = null;
-        const encCipher = await this.encrypt(cipher);
-        await this.saveWithServer(encCipher);
-
-        cipher.id = encCipher.id;
-        return super.shareWithServer(cipher, organizationId, collectionIds);
-    }
-
     async unshare(cipher: CipherView) {
-        // Hack: following line allows to delete/recreated a cipher instead of updating the existing one
-        // This hack allows to temporary fix a realtime sync problem from stack when we try
-        // to remove a cipher from an organization
-        //
-        // to remove hack, cipher.id = null should also be removed
-        await this.deleteWithServer(cipher.id);
-
         cipher.organizationId = null;
         cipher.collectionIds = null;
-        cipher.id = null;
 
         const encCipher = await this.encrypt(cipher);
 


### PR DESCRIPTION
This hack is not needed anymore since the stack has been fixed with
following commits :
- cozy/cozy-stack@d77516d7b185188150f7b7103cd1fbcac7318ada
- cozy/cozy-stack@ee45a0f0b365e294fd030be2159f69a2dc61276e
- cozy/cozy-stack@99b992c2671af50ee73e2ec5c27f37692a4e3a91

This reverts b7a39083e76bc48365d85e060d302a60eddb19b6