### PR TITLE
fix: delete the right local organization after a sync

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -46,7 +46,7 @@ export class UserService extends UserServiceBase {
 
         const oldOrganizations = await this.getAllOrganizations();
 
-        const newOrganizations = oldOrganizations.filter(organization => organization.id === organizationId);
+        const newOrganizations = oldOrganizations.filter(organization => organization.id !== organizationId);
 
         const organizationsData: { [id: string]: OrganizationData; } = {};
         newOrganizations.forEach(o => {


### PR DESCRIPTION
After receiving a delete notification, then `deleteOrganization()` was
removing all organizations from local memory except the one that should
have been removed

Hopefully the impact was only on client side and would be canceled
after a fullSync