### PR TITLE
feat: bump `cozy-sharing` version to 3.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7598,9 +7598,9 @@
       }
     },
     "cozy-sharing": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/cozy-sharing/-/cozy-sharing-3.12.0.tgz",
-      "integrity": "sha512-zFy2OVh2bG2FDYdjoJ0lRbXqJIpNXUyhGt0R3A5/9voVFGMBBjv6wDsmv1+hY9QbjpONDQ2gBMqLfsmWOTQBPQ==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/cozy-sharing/-/cozy-sharing-3.12.1.tgz",
+      "integrity": "sha512-q5Qaq9cc3Wd2ryuiV0Je3X1XGe7y3VW9JJO0YCCNQF+RVqjojb4x9dSJAD0df3Z01tbEg2pM8lacPldg8OVr/Q==",
       "requires": {
         "@cozy/minilog": "^1.0.0",
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "cozy-flags": "^2.7.2",
     "cozy-keys-lib": "^3.9.1",
     "cozy-realtime": "^3.13.0",
-    "cozy-sharing": "3.12.0",
+    "cozy-sharing": "3.12.1",
     "cozy-ui": "^54.0.0",
     "date-fns": "^1.30.1",
     "detect-browser": "5.2.0",


### PR DESCRIPTION
This retrieves a fix on `ConfirmTrustedRecipientsDialog` to correctly
display recipients' initials