### PR TITLE
fix: set correct text on "delete folder" button

### DIFF
--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -103,7 +103,7 @@
                             <app-cozy-icon ref="folder" width="24" height="16"></app-cozy-icon>
                             &nbsp;{{c.node.name}}
                         </a>
-                        <button appBlurClick (click)="deleteCollection(c.node)" appA11yTitle="{{'addFolder' | i18n}}">
+                        <button appBlurClick (click)="deleteCollection(c.node)" appA11yTitle="{{'deleteFolder' | i18n}}">
                             <app-cozy-icon ref="trash" width="20" height="16"></app-cozy-icon>
                         </button>
                         <ul class="fa-ul" *ngIf="c.children.length && !isCollapsed(c.node)">


### PR DESCRIPTION
Translation key was incorrect for the "delete folder" button