### PR TITLE
fix: add translations and icons for "download" CTA on iOS and Android

### DIFF
--- a/src/cozy/react/assets/store_android.svg
+++ b/src/cozy/react/assets/store_android.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fillRule="evenodd">
+    <path fill="#95999D"
+      d="M23.333 32H8.667C7.193 32 6 30.753 6 29.217V2.783C6 1.247 7.193 0 8.667 0h14.666C24.805 0 26 1.247 26 2.783v26.434C26 30.753 24.805 32 23.333 32z" />
+    <path fill="#F5F6F7" fillRule="nonzero" d="M14 2.001a.5.5 0 110-1L18 1a.5.5 0 110 1l-4 .001z" />
+    <path fill="#F5F6F7" d="M17.5 29.5a1.5 1.5 0 11-3.001-.001 1.5 1.5 0 013.001.001z" />
+    <path fill="#32363F" d="M7 3h18v25H7z" />
+  </g>
+</svg>

--- a/src/cozy/react/assets/store_ios.svg
+++ b/src/cozy/react/assets/store_ios.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fillRule="evenodd">
+    <path fill="#95999D"
+      d="M23.333 32H8.667C7.193 32 6 30.753 6 29.217V2.783C6 1.247 7.193 0 8.667 0h14.666C24.805 0 26 1.247 26 2.783v26.434C26 30.753 24.805 32 23.333 32z" />
+    <path fill="#F5F6F7" fillRule="nonzero" d="M14 2.001a.5.5 0 110-1L18 1a.5.5 0 110 1l-4 .001z" />
+    <path fill="#F5F6F7" d="M17.5 29.5a1.5 1.5 0 11-3.001-.001 1.5 1.5 0 013.001.001z" />
+    <path fill="#32363F" d="M7 3h18v25H7z" />
+  </g>
+</svg>

--- a/src/cozy/react/components/browserIcons.js
+++ b/src/cozy/react/components/browserIcons.js
@@ -6,6 +6,8 @@ import BrowserEdgeChromiumIcon from 'cozy-ui/transpiled/react/Icons/BrowserEdgeC
 import StoreChromeIcon from 'cozy/react/assets/store_chrome.svg'
 import StoreSafariIcon from 'cozy/react/assets/store_safari.svg'
 import StoreFirefoxIcon from 'cozy/react/assets/store_firefox.svg'
+import StoreIosIcon from 'cozy/react/assets/store_ios.svg'
+import StoreAndroidIcon from 'cozy/react/assets/store_android.svg'
 
 const browserIcons = {
   safari: BrowserSafariIcon,
@@ -18,7 +20,9 @@ export const extensionStoresIcons = {
   chrome: StoreChromeIcon,
   safari: StoreSafariIcon,
   firefox: StoreFirefoxIcon,
-  'edge-chromium': StoreChromeIcon
+  'edge-chromium': StoreChromeIcon,
+  ios: StoreIosIcon,
+  android: StoreAndroidIcon
 }
 
 export default browserIcons

--- a/src/cozy/react/locales/en.json
+++ b/src/cozy/react/locales/en.json
@@ -153,9 +153,11 @@
   "Vault": {
     "extension": {
       "cta": {
+        "android": "Install Cozy Pass application",
         "chrome": "Install on Chrome",
         "edge-chromium": "Install on Edge",
         "firefox": "Install on Firefox",
+        "ios": "Install Cozy Pass application",
         "safari": "Install on Safari"
       }
     },

--- a/src/cozy/react/locales/fr.json
+++ b/src/cozy/react/locales/fr.json
@@ -152,9 +152,11 @@
   "Vault": {
     "extension": {
       "cta": {
+        "android": "Installer l'application Cozy Pass",
         "chrome": "Installer sur Chrome",
         "edge-chromium": "Installer sur Edge",
         "firefox": "Installer sur Firefox",
+        "ios": "Installer l'application Cozy Pass",
         "safari": "Installer sur Safari"
       }
     },


### PR DESCRIPTION
As CozyPass web was not ready to be used on mobile, we did not try the
CTA feature on those platforms

CozyPass web is not ready yet, but the `import` settings from CozyPass
mobile opens CozyPass web from the mobile. So we have to fix this issue

Generic `PhoneDevice` icon is used for both Android and iOS. This may
be replaced later with real stores icons when ready