### PR TITLE
feat: re-enable notes

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -271,7 +271,6 @@
                     </a> -->
                 </div>
             </div>
-            <!-- Notes are disabled to avoid confusion with Cozy Notes
             <div class="box">
                 <div class="box-header">
                     <label for="notes">{{'notes' | i18n}}</label>
@@ -282,7 +281,6 @@
                     </div>
                 </div>
             </div>
-            -->
             <div class="box">
                 <div class="box-header">
                     {{'customFields' | i18n}}

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -118,7 +118,7 @@
     "message": "Website"
   },
   "notes": {
-    "message": "Notes"
+    "message": "Description"
   },
   "customFields": {
     "message": "Custom Fields"

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -118,7 +118,7 @@
     "message": "Site web"
   },
   "notes": {
-    "message": "Notes"
+    "message": "Description"
   },
   "customFields": {
     "message": "Champs personnalisés"


### PR DESCRIPTION
Notes were disabled to avoid confusion with Cozy Notes

We enable them again but named as Description

Related commit: 93e2d903f190b6c5570c4d5b134dac53184adbb8