### PR TITLE
feat: remove `passwords.can-share-organizations` flag on folders display

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -375,12 +375,10 @@
                         {{'cancel' | i18n}}
                     </button>
                     <div class="right">
-                        <ng-container *ifFlag="CAN_SHARE_ORGANIZATION">
                         <button appBlurClick type="button" (click)="share()" appA11yTitle="{{'shareItem' | i18n}}"
                             *ngIf="editMode && cipher && !cloneMode">
                             <i class="fa fa-share-alt fa-lg fa-fw" aria-hidden="true"></i>
                         </button>
-                        </ng-container>
                         <button #deleteBtn appBlurClick type="button" (click)="delete()" class="danger"
                             appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode && !cloneMode" [disabled]="deleteBtn.loading"
                             [appApiAction]="deletePromise">

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -23,8 +23,6 @@ import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
 
 import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/components/add-edit.component';
 
-import { CAN_SHARE_ORGANIZATION } from '../../cozy/flags';
-
 const BroadcasterSubscriptionId = 'AddEditComponent';
 
 @Component({
@@ -32,7 +30,6 @@ const BroadcasterSubscriptionId = 'AddEditComponent';
     templateUrl: 'add-edit.component.html',
 })
 export class AddEditComponent extends BaseAddEditComponent implements OnChanges, OnDestroy {
-    CAN_SHARE_ORGANIZATION = CAN_SHARE_ORGANIZATION;
     @ViewChild('form')
     private form: NgForm;
     constructor(cipherService: CipherService, folderService: FolderService,

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -52,7 +52,9 @@
         class="block primary" appA11yTitle="{{'addItem' | i18n}}" [disabled]="deleted">
         <i class="fa fa-plus fa-lg" aria-hidden="true"></i>
     </button>
+    <ng-container *ifFlag="CAN_SHARE_ORGANIZATION">
     <app-sharing *ngIf="collectionId && !isCozyConnectors" [collectionId]="collectionId"></app-sharing>
+    </ng-container>
     <app-bottom-menu
         *ngIf="!isReadOnly"
         [isTrashContext]="deleted"

--- a/src/app/vault/ciphers.component.ts
+++ b/src/app/vault/ciphers.component.ts
@@ -11,6 +11,8 @@ import { CipherView } from 'jslib/models/view/cipherView';
 
 import { UserService } from '../../services/user.service';
 
+import { CAN_SHARE_ORGANIZATION } from '../../cozy/flags';
+
 @Component({
     selector: 'app-vault-ciphers',
     templateUrl: 'ciphers.component.html',
@@ -22,6 +24,7 @@ export class CiphersComponent extends BaseCiphersComponent {
 
     isReadOnly = false;
     isCozyConnectors = false;
+    CAN_SHARE_ORGANIZATION = CAN_SHARE_ORGANIZATION;
 
     constructor(searchService: SearchService, protected platformUtilsService: PlatformUtilsService,
         protected i18nService: I18nService, protected cipherService: CipherService,

--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -89,7 +89,7 @@
         <ng-container *ngIf="loaded">
             <div class="heading">
                 <h2>{{'folders' | i18n}}</h2>
-                <button appBlurClick (click)="addFolder()" appA11yTitle="{{'addFolder' | i18n}}" *ifFlag="CAN_SHARE_ORGANIZATION">
+                <button appBlurClick (click)="addFolder()" appA11yTitle="{{'addFolder' | i18n}}">
                     <i class="fa fa-plus fa-fw" aria-hidden="true"></i>
                 </button>
             </div>
@@ -113,9 +113,7 @@
                         </ul>
                     </li>
                 </ng-template>
-                <ng-container *ifFlag="CAN_SHARE_ORGANIZATION">
                 <ng-container *ngTemplateOutlet="recursiveCollections; context:{ $implicit: nestedCollections }">
-                </ng-container>
                 </ng-container>
 
                 <li [ngClass]="{active: selectedTrash}">


### PR DESCRIPTION
Folders are now displayed for everyone, so the flag has been removed
from code responsible for displaying folders

Share feature should stay behind a flag, so we added a flag on it
(before this button was not accessible as the flag was placed on parent
component)

____

With this PR users can now :
- See folders list on the left navigation pane and navigate through them
- Click on the "add folder" icon (`+`) on the folder list
- Click on the "delete folder" icon on the folder list
- Click the "share cipher" button when editing a cipher in order to add it to an existing folder

Users still cannot (hidden behind flag) : 
- See the `Cozy Share` button on a folder view
- See the `Security code` button on the left navigation pane (this is used only when receiving a sharing)