### PR TITLE
feat: Add mobile info in manifest.webapp

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -94,5 +94,10 @@
       "type": "io.cozy.sharings",
       "verbs": ["GET", "POST"]
     }
+  },
+  "mobile": {
+    "schema": "cozypass://",
+    "id_playstore": "io.cozy.pass",
+    "id_appstore": "cozy-pass/id1502262449"
   }
 }


### PR DESCRIPTION
This information can be used to open the native CozyPass app from
another Cozy app

Related PR: https://github.com/cozy/cozy-react-native/pull/65