### PR TITLE
fix: Replace `yarn` by `npm` for `build` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "GPL-3.0",
   "scripts": {
-    "build": "yarn build:browser:prod",
+    "build": "npm run build:browser:prod",
     "start": "npm run build:browser:watch",
     "sub:init": "git submodule update --init --recursive",
     "sub:update": "git submodule update --remote",


### PR DESCRIPTION
In 8d36b7c5b9d3bfb4167b66a0c0469f36bed3636b the `build` script has been added using `yarn`

But the entire project uses `npm` so we want to homogenise the script