### PR TITLE
feat: Prevent spellcheck feature on form fields

### DIFF
--- a/src/app/accounts/lock.component.html
+++ b/src/app/accounts/lock.component.html
@@ -8,12 +8,12 @@
                     <div class="row-main" *ngIf="pinLock">
                         <label for="pin">{{'pin' | i18n}}</label>
                         <input id="pin" type="{{showPassword ? 'text' : 'password'}}" name="PIN" class="monospaced"
-                            [(ngModel)]="pin" required appAutofocus>
+                            [(ngModel)]="pin" required appAutofocus appInputVerbatim>
                     </div>
                     <div class="row-main" *ngIf="!pinLock">
                         <label for="masterPassword">{{'masterPass' | i18n}}</label>
                         <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}" name="MasterPassword"
-                            class="monospaced" [(ngModel)]="masterPassword" required appAutofocus>
+                            class="monospaced" [(ngModel)]="masterPassword" required appAutofocus appInputVerbatim>
                     </div>
                     <div class="action-buttons">
                         <a class="row-btn" href="#" appStopClick appBlurClick role="button"

--- a/src/app/accounts/login.component.html
+++ b/src/app/accounts/login.component.html
@@ -11,7 +11,7 @@
                 <p class="u-error" *ngIf="errorMsg !== ''">{{errorMsg}}</p>
                 <div class="box-content-row" appBoxRow *ngIf="!isInCozyApp">
                     <label for="email">email address (required only when executed outside a Cozy app "me@fqdn.mycozy.cloud")</label>
-                    <input id="email" type="text" name="Email" [(ngModel)]="email" required>
+                    <input id="email" type="text" name="Email" [(ngModel)]="email" required appInputVerbatim>
                 </div>
                 <div class="row material-input eyed" #masterPwdContainer>
                     <div class="visible-label">
@@ -22,7 +22,7 @@
                         <label class="shadow-label"></label>
                         <div class="box-input">
                             <input id="masterPassword" inputmode="url" name="MasterPassword"
-                                placeholder="" [(ngModel)]="masterPassword" type="password" required>
+                                placeholder="" [(ngModel)]="masterPassword" type="password" required appInputVerbatim>
                             <div id="visi-pwd-btn" class="visibility-btn">
                                 <i class="fa fa-mg fa-eye"></i>
                             </div>

--- a/src/app/accounts/two-factor.component.html
+++ b/src/app/accounts/two-factor.component.html
@@ -10,7 +10,7 @@
             <div class="box-content">
                 <div class="box-content-row" appBoxRow>
                     <label for="code">{{'verificationCode' | i18n}}</label>
-                    <input id="code" type="text" name="Code" [(ngModel)]="token" required appAutofocus>
+                    <input id="code" type="text" name="Code" [(ngModel)]="token" required appAutofocus appInputVerbatim>
                 </div>
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>
                     <label for="remember">{{'rememberMe' | i18n}}</label>
@@ -25,7 +25,7 @@
                 <div class="box-content">
                     <div class="box-content-row" appBoxRow>
                         <label for="code" class="sr-only">{{'verificationCode' | i18n}}</label>
-                        <input id="code" type="password" name="Code" [(ngModel)]="token" required appAutofocus>
+                        <input id="code" type="password" name="Code" [(ngModel)]="token" required appAutofocus appInputVerbatim>
                     </div>
                     <div class="box-content-row box-content-row-checkbox" appBoxRow>
                         <label for="remember">{{'rememberMe' | i18n}}</label>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { AutofocusDirective } from 'jslib/angular/directives/autofocus.directive
 import { BlurClickDirective } from 'jslib/angular/directives/blur-click.directive';
 import { BoxRowDirective } from 'jslib/angular/directives/box-row.directive';
 import { FallbackSrcDirective } from 'jslib/angular/directives/fallback-src.directive';
+import { InputVerbatimDirective } from 'jslib/angular/directives/input-verbatim.directive';
 import { SelectCopyDirective } from 'jslib/angular/directives/select-copy.directive';
 import { StopClickDirective } from 'jslib/angular/directives/stop-click.directive';
 import { StopPropDirective } from 'jslib/angular/directives/stop-prop.directive';
@@ -200,6 +201,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         HintComponent,
         I18nPipe,
         IconComponent,
+        InputVerbatimDirective,
         LockComponent,
         LoginComponent,
         ModalComponent,

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -17,21 +17,21 @@
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="name">{{'name' | i18n}}</label>
-                        <input id="name" type="text" name="Name" [(ngModel)]="cipher.name" [appAutofocus]="!editMode">
+                        <input id="name" type="text" name="Name" [(ngModel)]="cipher.name" [appAutofocus]="!editMode" appInputVerbatim>
                     </div>
                     <!-- Login -->
                     <div *ngIf="cipher.type === cipherType.Login">
                         <div class="box-content-row" appBoxRow>
                             <label for="loginUsername">{{'username' | i18n}}</label>
                             <input id="loginUsername" type="text" name="Login.Username"
-                                [(ngModel)]="cipher.login.username">
+                                [(ngModel)]="cipher.login.username" appInputVerbatim>
                         </div>
                         <div class="box-content-row box-content-row-flex" appBoxRow>
                             <div class="row-main">
                                 <label for="loginPassword">{{'password' | i18n}}</label>
                                 <input id="loginPassword" class="monospaced"
                                     type="{{showPassword ? 'text' : 'password'}}" name="Login.Password"
-                                    [(ngModel)]="cipher.login.password" [disabled]="!cipher.viewPassword">
+                                    [(ngModel)]="cipher.login.password" [disabled]="!cipher.viewPassword" appInputVerbatim>
                             </div>
                             <div class="action-buttons" *ngIf=cipher.viewPassword>
                                 <button type="button" #checkPasswordBtn class="row-btn btn" appBlurClick
@@ -66,13 +66,13 @@
                         <div class="box-content-row" appBoxRow>
                             <label for="cardCardholderName">{{'cardholderName' | i18n}}</label>
                             <input id="cardCardholderName" type="text" name="Card.CardCardholderName"
-                                [(ngModel)]="cipher.card.cardholderName">
+                                [(ngModel)]="cipher.card.cardholderName" appInputVerbatim>
                         </div>
                         <div class="box-content-row box-content-row-flex" appBoxRow>
                             <div class="row-main">
                                 <label for="cardNumber">{{'number' | i18n}}</label>
                                 <input id="cardNumber" class="monospaced" type="{{showCardNumber ? 'text' : 'password'}}"
-                                    name="Card.Number" [(ngModel)]="cipher.card.number">
+                                    name="Card.Number" [(ngModel)]="cipher.card.number" appInputVerbatim>
                             </div>
                             <div class="action-buttons">
                                 <a class="row-btn" href="#" appStopClick appBlurClick role="button"
@@ -97,13 +97,13 @@
                         <div class="box-content-row" appBoxRow>
                             <label for="cardExpYear">{{'expirationYear' | i18n}}</label>
                             <input id="cardExpYear" type="text" name="Card.ExpYear" [(ngModel)]="cipher.card.expYear"
-                                placeholder="{{'ex' | i18n}} {{currentDate | date: 'yyyy'}}">
+                                placeholder="{{'ex' | i18n}} {{currentDate | date: 'yyyy'}}" appInputVerbatim>
                         </div>
                         <div class="box-content-row box-content-row-flex" appBoxRow>
                             <div class="row-main">
                                 <label for="cardCode">{{'securityCode' | i18n}}</label>
                                 <input id="cardCode" class="monospaced" type="{{showCardCode ? 'text' : 'password'}}"
-                                    name="Card.Code" [(ngModel)]="cipher.card.code">
+                                    name="Card.Code" [(ngModel)]="cipher.card.code" appInputVerbatim>
                             </div>
                             <div class="action-buttons">
                                 <a class="row-btn" href="#" appStopClick appBlurClick role="button"
@@ -125,82 +125,82 @@
                         <div class="box-content-row" appBoxRow>
                             <label for="idFirstName">{{'firstName' | i18n}}</label>
                             <input id="idFirstName" type="text" name="Identity.FirstName"
-                                [(ngModel)]="cipher.identity.firstName">
+                                [(ngModel)]="cipher.identity.firstName" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idMiddleName">{{'middleName' | i18n}}</label>
                             <input id="idMiddleName" type="text" name="Identity.MiddleName"
-                                [(ngModel)]="cipher.identity.middleName">
+                                [(ngModel)]="cipher.identity.middleName" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idLastName">{{'lastName' | i18n}}</label>
                             <input id="idLastName" type="text" name="Identity.LastName"
-                                [(ngModel)]="cipher.identity.lastName">
+                                [(ngModel)]="cipher.identity.lastName" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idUsername">{{'username' | i18n}}</label>
                             <input id="idUsername" type="text" name="Identity.Username"
-                                [(ngModel)]="cipher.identity.username">
+                                [(ngModel)]="cipher.identity.username" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idCompany">{{'company' | i18n}}</label>
                             <input id="idCompany" type="text" name="Identity.Company"
-                                [(ngModel)]="cipher.identity.company">
+                                [(ngModel)]="cipher.identity.company" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idSsn">{{'ssn' | i18n}}</label>
-                            <input id="idSsn" type="text" name="Identity.SSN" [(ngModel)]="cipher.identity.ssn">
+                            <input id="idSsn" type="text" name="Identity.SSN" [(ngModel)]="cipher.identity.ssn" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idPassportNumber">{{'passportNumber' | i18n}}</label>
                             <input id="idPassportNumber" type="text" name="Identity.PassportNumber"
-                                [(ngModel)]="cipher.identity.passportNumber">
+                                [(ngModel)]="cipher.identity.passportNumber" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idLicenseNumber">{{'licenseNumber' | i18n}}</label>
                             <input id="idLicenseNumber" type="text" name="Identity.LicenseNumber"
-                                [(ngModel)]="cipher.identity.licenseNumber">
+                                [(ngModel)]="cipher.identity.licenseNumber" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idEmail">{{'email' | i18n}}</label>
-                            <input id="idEmail" type="text" name="Identity.Email" [(ngModel)]="cipher.identity.email">
+                            <input id="idEmail" type="text" name="Identity.Email" [(ngModel)]="cipher.identity.email" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idPhone">{{'phone' | i18n}}</label>
-                            <input id="idPhone" type="text" name="Identity.Phone" [(ngModel)]="cipher.identity.phone">
+                            <input id="idPhone" type="text" name="Identity.Phone" [(ngModel)]="cipher.identity.phone" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idAddress1">{{'address1' | i18n}}</label>
                             <input id="idAddress1" type="text" name="Identity.Address1"
-                                [(ngModel)]="cipher.identity.address1">
+                                [(ngModel)]="cipher.identity.address1" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idAddress2">{{'address2' | i18n}}</label>
                             <input id="idAddress2" type="text" name="Identity.Address2"
-                                [(ngModel)]="cipher.identity.address2">
+                                [(ngModel)]="cipher.identity.address2" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idAddress3">{{'address3' | i18n}}</label>
                             <input id="idAddress3" type="text" name="Identity.Address3"
-                                [(ngModel)]="cipher.identity.address3">
+                                [(ngModel)]="cipher.identity.address3" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idCity">{{'cityTown' | i18n}}</label>
-                            <input id="idCity" type="text" name="Identity.City" [(ngModel)]="cipher.identity.city">
+                            <input id="idCity" type="text" name="Identity.City" [(ngModel)]="cipher.identity.city" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idState">{{'stateProvince' | i18n}}</label>
-                            <input id="idState" type="text" name="Identity.State" [(ngModel)]="cipher.identity.state">
+                            <input id="idState" type="text" name="Identity.State" [(ngModel)]="cipher.identity.state" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idPostalCode">{{'zipPostalCode' | i18n}}</label>
                             <input id="idPostalCode" type="text" name="Identity.PostalCode"
-                                [(ngModel)]="cipher.identity.postalCode">
+                                [(ngModel)]="cipher.identity.postalCode" appInputVerbatim>
                         </div>
                         <div class="box-content-row" appBoxRow>
                             <label for="idCountry">{{'country' | i18n}}</label>
                             <input id="idCountry" type="text" name="Identity.Country"
-                                [(ngModel)]="cipher.identity.country">
+                                [(ngModel)]="cipher.identity.country" appInputVerbatim>
                         </div>
                     </div>
                 </div>
@@ -216,7 +216,7 @@
                             <div class="row-main">
                                 <label for="loginUri{{i}}">{{'uriPosition' | i18n : (i + 1)}}</label>
                                 <input id="loginUri{{i}}" type="text" name="Login.Uris[{{i}}].Uri" [(ngModel)]="u.uri"
-                                    placeholder="{{'ex' | i18n}} https://google.com">
+                                    placeholder="{{'ex' | i18n}} https://google.com" appInputVerbatim>
                                 <label for="loginUriMatch{{i}}" class="sr-only">
                                     {{'matchDetection' | i18n}} {{(i + 1)}}
                                 </label>
@@ -277,7 +277,7 @@
                 </div>
                 <div class="box-content">
                     <div class="box-content-row" appBoxRow>
-                        <textarea id="notes" name="Notes" rows="6" [(ngModel)]="cipher.notes"></textarea>
+                        <textarea id="notes" name="Notes" rows="6" [(ngModel)]="cipher.notes" appInputVerbatim></textarea>
                     </div>
                 </div>
             </div>
@@ -298,13 +298,13 @@
                             <label for="fieldValue{{i}}" class="sr-only">{{'value' | i18n}}</label>
                             <div class="row-main">
                                 <input id="fieldName{{i}}" type="text" name="Field.Name{{i}}" [(ngModel)]="f.name"
-                                    class="row-label" placeholder="{{'name' | i18n}}">
+                                    class="row-label" placeholder="{{'name' | i18n}}" appInputVerbatim>
                                 <input id="fieldValue{{i}}" type="text" name="Field.Value{{i}}" [(ngModel)]="f.value"
-                                    *ngIf="f.type === fieldType.Text" placeholder="{{'value' | i18n}}">
+                                    *ngIf="f.type === fieldType.Text" placeholder="{{'value' | i18n}}" appInputVerbatim>
                                 <input id="fieldValue{{i}}" type="{{f.showValue ? 'text' : 'password'}}"
                                     name="Field.Value{{i}}" [(ngModel)]="f.value" class="monospaced"
                                     *ngIf="f.type === fieldType.Hidden" placeholder="{{'value' | i18n}}"
-                                    [disabled]="!cipher.viewPassword && !f.newField">
+                                    [disabled]="!cipher.viewPassword && !f.newField" appInputVerbatim>
                             </div>
                             <input id="fieldValue{{i}}" name="Field.Value{{i}}" type="checkbox" [(ngModel)]="f.value"
                                 *ngIf="f.type === fieldType.Boolean" appTrueFalseValue trueValue="true"

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -1,7 +1,7 @@
 <div class="header header-search">
     <div class="search">
         <input type="search" placeholder="{{searchPlaceholder || ('searchVault' | i18n)}}" id="search"
-            [(ngModel)]="searchText" (input)="search(200)" autocomplete="off" appAutofocus>
+            [(ngModel)]="searchText" (input)="search(200)" autocomplete="off" appAutofocus appInputVerbatim>
         <i class="fa fa-search" aria-hidden="true"></i>
     </div>
 </div>

--- a/src/app/vault/export.component.html
+++ b/src/app/vault/export.component.html
@@ -20,7 +20,7 @@
                                 <label for="masterPassword">{{'masterPass' | i18n}}</label>
                                 <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}"
                                     name="MasterPassword" class="monospaced" [(ngModel)]="masterPassword" required
-                                    appAutofocus>
+                                    appAutofocus appInputVerbatim>
                             </div>
                             <div class="action-buttons">
                                 <a class="row-btn" href="#" appStopClick appBlurClick role="button"

--- a/src/app/vault/folder-add-edit.component.html
+++ b/src/app/vault/folder-add-edit.component.html
@@ -10,7 +10,7 @@
                         <div class="box-content-row" appBoxRow>
                             <label for="name">{{'name' | i18n}}</label>
                             <input id="name" type="text" name="Name" [(ngModel)]="folder.name"
-                                [appAutofocus]="!editMode">
+                                [appAutofocus]="!editMode" appInputVerbatim>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Everything protected in the vault should be considered as sensible data that should not leak through browser's enhanced spellcheck

So we want to disable spellcheck on cozy-pass fields like password fields, names, urls, notes, address etc

This commit does not handle `send` feature fields as it deactivated and so we are not able to test it. But this should be considered if we implement it in the future

More info: https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords

Related issue: bitwarden/desktop#842
___

This PR reflects https://github.com/cozy/cozy-keys-browser/pull/144