### PR TITLE
feat: Add a badge to share button when users are waiting for validation

### DIFF
--- a/src/scss/cozy.scss
+++ b/src/scss/cozy.scss
@@ -145,6 +145,22 @@ app-vault-ciphers {
 
     app-sharing {
         margin: 0 10px;
+        .collectionWithUsersToValidate {
+            &:after {
+                content: '';
+                background-color: var(--errorColor);
+                width: 7px;
+                height: 7px;
+                border-radius: 6px;
+                position: absolute;
+                right: -6px;
+                top: -6px;
+                border: 2px solid;
+                @include themify($themes) {
+                    border-color: themed('backgroundColorAlt2');
+                }
+            }
+        }
     }
     
     .footer.readonlyCipher {


### PR DESCRIPTION
In #81 we added a badge on folders shared with another user that has not been valitated yet

When opening those folders, it was unclear for the user what to do next

So we want to add another badge on the Share button to indicates to the user that the next action is to go on the Share dialog which contains info about waiting users

![image](https://user-images.githubusercontent.com/1884255/197541593-238b7356-2cb7-4c1d-b56d-5be862ef1e49.png)
