### PR TITLE
fix: Prevent ConfirmTrustedUsers modal to be displayed on race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## 🐛 Bug Fixes
 
+* Fixes a bug that may display the contact confirmation dialog even if not necessary
+
 ## 🔧 Tech
 
 # 2.0.7

--- a/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
+++ b/src/cozy/wrappers/confirm-trusted-users/confirm-trusted-users.component.ts
@@ -95,7 +95,6 @@ export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
                     if (this.waitForFirstSync) {
                         this.waitForFirstSync = false;
 
-                        this.showModal = true;
                         this.firstRenderReact();
                     }
                     break;
@@ -129,6 +128,7 @@ export class ConfirmTrustedUsersComponent extends AngularWrapperComponent {
             return;
         }
 
+        this.showModal = true;
         this.renderReact();
     }
 


### PR DESCRIPTION
With previous implementation, if the `syncCompleted` happens before the first `renderReact()`, then the ConfirmTrustedUsers modal would be displayed even if there is no contact to confirm

In nominal scenario, the component would call `renderReact()` one to two times

The first render is always called and should be done with `showModal = false` and so the component should not be displayed

Then the component should receive the `syncCompleted` event, which should call `firstRenderReact()` that should check for users to be confirmed and then trigger `renderReact()` if necessary

But `showModal = true` was not conditioned to the presence of users to be confirmed. This is responsible of a race condition with the first `renderReact()` call

By moving `showModal = true` behind the condition, then the component can never be shown if there is no users to be confirmed