### PR TITLE
fix: Make the CI target release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only:
   - master
   # tags
-  - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
+  - /^release\/\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
     - MATTERMOST_CHANNEL='{"dev":"feat---password-mgr","beta":"feat---password-mgr,publication","stable":"feat---password-mgr,publication"}'


### PR DESCRIPTION
We encountered a bug that prevents travis to trigger builds on tags

This makes the release builds impossible

To fix that we change the branches rules to target `release/x.y.z` branches instead of `x.y.z` tags

With this edit, we should be able to trigger release builds on tags if they are based on a `release/x.y.z` branch