### PR TITLE
fix: Re-enable Alerter in react components

### DIFF
--- a/src/cozy/react/components/InstallationPage/components/HintStep.jsx
+++ b/src/cozy/react/components/InstallationPage/components/HintStep.jsx
@@ -39,7 +39,11 @@ const HintStep = ({ navigate }) => {
 
       goToNextStep()
     } catch (err) {
-      Alerter.error(t('HintStep.error'))
+      if (err.status === 422 && err.reason?.errors?.[0].detail === 'The hint cannot be the same as the password') {
+        Alerter.error(t('HintStep.errorSamePassword'))
+      } else {
+        Alerter.error(t('HintStep.error'))
+      }
 
       // eslint-disable-next-line no-console
       console.error(err)

--- a/src/cozy/react/locales/en.json
+++ b/src/cozy/react/locales/en.json
@@ -52,6 +52,7 @@
     "submit": "Save the hint",
     "skip": "Skip",
     "error": "Error while updating hint",
+    "errorSamePassword": "The hint cannot be the same as the password",
     "please-configure-hint": "Please configure a hint",
     "hint-configured": "Hint configured ✅ You can still change it here."
   },

--- a/src/cozy/react/locales/fr.json
+++ b/src/cozy/react/locales/fr.json
@@ -52,6 +52,7 @@
     "submit": "Enregistrer l'indice",
     "skip": "Passer",
     "error": "Erreur lors de la mise à jour de l'indice",
+    "errorSamePassword": "L'indice ne peut pas être identique à votre mot de passe",
     "please-configure-hint": "Merci de configurer un indice",
     "hint-configured": "Indice défini ✅ Vous pouvez toujours le changer ici."
   },

--- a/src/cozy/wrappers/react-wrapper.jsx
+++ b/src/cozy/wrappers/react-wrapper.jsx
@@ -6,6 +6,7 @@ import { CozyProvider } from "cozy-client";
 import { VaultProvider } from "cozy-keys-lib";
 import { BreakpointsProvider } from "cozy-ui/transpiled/react/hooks/useBreakpoints";
 import { WebviewIntentProvider } from "cozy-intent";
+import Alerter from 'cozy-ui/transpiled/react/Alerter';
 import { I18n } from "cozy-ui/transpiled/react/I18n";
 import React from "react";
 import PropTypes from 'prop-types';
@@ -76,6 +77,7 @@ const ReactWrapper = ({
                 <BreakpointsProvider>
                   <MuiCozyTheme>
                     <HashRouter>{props.children}</HashRouter>
+                    <Alerter />
                   </MuiCozyTheme>
                 </BreakpointsProvider>
               </WebviewIntentProvider>


### PR DESCRIPTION
When migrating `installation` components from React's router into
Angular's one, we lost the `Alerter` component that would react to
`Alerter.error()` calls

We want to re-introduce the `Alerter` in the react-wrapper component so
it would be accessible to all previously migrated components

Related commit: f66210c84581647929ca2641a6611aa2fe34dcef
Related commit: 0251b221637eba47a52512c605aefad3a3f2c021

This PR also improves the error message displayed when the Hint is the same as Password in the installation page