### PR TITLE
[VO-99] fix: Call vault migration on onboarding's end

### DIFF
--- a/src/cozy/services/installation-guard.service.ts
+++ b/src/cozy/services/installation-guard.service.ts
@@ -32,7 +32,12 @@ export class VaultInstallationService {
         }
     }
 
-    setIsInstalled() {
+    async completeVaultConfiguration() {
+        const client = this.clientService.GetClient();
+        await client.stackClient.fetchJSON(
+            'POST',
+            '/settings/vault'
+        );
         this.userFinishedInstallation = true;
     }
 }

--- a/src/cozy/wrappers/installation-page/installation-page.component.ts
+++ b/src/cozy/wrappers/installation-page/installation-page.component.ts
@@ -84,8 +84,8 @@ export class InstallationPageComponent extends AngularWrapperComponent implement
     /* Props Bindings */
     /******************/
 
-    protected onSkipExtension() {
-        this.vaultInstallationService.setIsInstalled();
+    protected async onSkipExtension() {
+        await this.vaultInstallationService.completeVaultConfiguration();
         this.messagingService.send('installed');
     }
 


### PR DESCRIPTION
In a previous commit we changed the bitwarden client's type from `webapp` to `web`

This had a side effect on onboarding that would not trigger migration from konnectors accounts to ciphers as this is prevented on `web` clients (because cozy-keys-lib is also flagged as a `web` client)

This is a requirement for setting `extension_installed` flag to `true`

The result was the onboarding screen to be always displayed when accessing cozy-pass-web

To fix this, the cozy-stack now has a new entry point `/settings/vault` that allows to enforce the migration from cozy-pass-web even if its client is a `web` one

We want to call this endpoint at the end of onboarding

Related PR: #109
Related PR: cozy/cozy-stack#4285
Related PR: cozy/cozy-stack#4303