### PR TITLE
fix: Make the CI target tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only:
   - master
   # tags
-  - /^release\/\d+\.\d+\.\d+(\-beta.\d+)?$/
+  - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
     - MATTERMOST_CHANNEL='{"dev":"feat---password-mgr","beta":"feat---password-mgr,publication","stable":"feat---password-mgr,publication"}'


### PR DESCRIPTION
In #112 we fixed a travis bug that prevented builds to be triggered by tags

Since then Travis fixed that issue and now we should revert previous commit in order to make CI work again